### PR TITLE
include tags explicitly

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -1,3 +1,7 @@
+trigger:
+  tags:
+    include:
+    - v*
 
 jobs:
   - job: Build


### PR DESCRIPTION
It looks like you need to include tags explicitly: 
https://stackoverflow.com/questions/52615283/how-do-you-trigger-a-build-in-azure-pipelines-when-a-new-tag-is-pushed-to-github

The docs seem to indicate otherwise though:
https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops&tabs=yaml#tags