### PR TITLE
chore(build): multi target net framework as well as net standard

### DIFF
--- a/src/AgDatabaseMove.csproj
+++ b/src/AgDatabaseMove.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>0.1.0-pre</Version>
     <Authors>Ryan Clare</Authors>


### PR DESCRIPTION
When referencing the package from a .NET Framework application run time errors occurred due assembly version conflicts in SMO. Multi targeting this library resolves those conflicts.