### PR TITLE
fix(tests): integration tests were broken

### DIFF
--- a/src/Restore.cs
+++ b/src/Restore.cs
@@ -50,7 +50,7 @@
 
     internal LoginProperties UpdateDefaultDb(LoginProperties loginProperties)
     {
-      loginProperties.DefaultDatabase = _source.Name == loginProperties.DefaultDatabase ? _destination.Name : null;
+      loginProperties.DefaultDatabase = _source.Name == loginProperties.DefaultDatabase ? _destination.Name : "master";
       return loginProperties;
     }
 

--- a/tests/AgDatabaseMove.Integration/TestRestore.cs
+++ b/tests/AgDatabaseMove.Integration/TestRestore.cs
@@ -103,7 +103,7 @@ namespace AgDatabaseMove.Integration
         }
 
         var fillTableSql =
-          "INSERT INTO TestSync (script) (SELECT TOP 10000 sm.[definition] FROM sys.all_sql_modules AS sm CROSS JOIN sys.all_sql_modules AS asm)";
+          "INSERT INTO TestSync (script) (SELECT TOP 100000 sm.[definition] FROM sys.all_sql_modules AS sm CROSS JOIN sys.all_sql_modules AS asm)";
         using(var fillTable = new SqlCommand(fillTableSql, connection)) {
           fillTable.ExecuteNonQuery();
         }

--- a/tests/AgDatabaseMove.Unit/RestoreTests.cs
+++ b/tests/AgDatabaseMove.Unit/RestoreTests.cs
@@ -18,7 +18,7 @@
 
     [Theory]
     [InlineData("foo", "foo", "foo")]
-    [InlineData("bar", "bar", null)]
+    [InlineData("bar", "bar", "master")]
     [InlineData("foo", "bar", "bar")]
     public void DefaultDatabase(string sourceDbName, string destinationDbName, string defaultDb)
     {


### PR DESCRIPTION
* Default databases weren't set as expected in the integration environment. Ensure we set a default (master) for any logins we're moving.
* Our fillTable script wasn't generating enough load to put the secondaries in the initializing state.