### PR TITLE
fix(case): use case insensitive comparisons

### DIFF
--- a/src/Restore.cs
+++ b/src/Restore.cs
@@ -50,7 +50,10 @@
 
     internal LoginProperties UpdateDefaultDb(LoginProperties loginProperties)
     {
-      loginProperties.DefaultDatabase = _source.Name == loginProperties.DefaultDatabase ? _destination.Name : "master";
+      loginProperties.DefaultDatabase =
+        _source.Name.Equals(loginProperties.DefaultDatabase, StringComparison.InvariantCultureIgnoreCase)
+          ? _destination.Name
+          : "master";
       return loginProperties;
     }
 

--- a/src/SmoFacade/AvailabilityGroup.cs
+++ b/src/SmoFacade/AvailabilityGroup.cs
@@ -19,7 +19,9 @@
       _availabilityGroup = availabilityGroup;
     }
 
-    public bool IsPrimaryInstance => _availabilityGroup.PrimaryReplicaServerName == _availabilityGroup.Parent.NetName;
+    public bool IsPrimaryInstance =>
+      _availabilityGroup.PrimaryReplicaServerName.Equals(_availabilityGroup.Parent.NetName,
+                                                         StringComparison.InvariantCultureIgnoreCase);
 
     public string PrimaryInstance => _availabilityGroup.PrimaryReplicaServerName;
     public string Name => _availabilityGroup.Name;
@@ -59,7 +61,7 @@
     {
       // The availability database needs to be refreshed since the state changes on the server side.
       var availabilityDatabase = _availabilityGroup.AvailabilityDatabases.Cast<Smo.AvailabilityDatabase>()
-        .SingleOrDefault(d => d.Name == dbName);
+        .SingleOrDefault(d => d.Name.Equals(dbName, StringComparison.InvariantCultureIgnoreCase));
       if(availabilityDatabase == null)
         return false;
       availabilityDatabase.Refresh();

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -199,7 +199,8 @@
     public void EnsureLogins(IEnumerable<LoginProperties> newLogins)
     {
       foreach(var login in newLogins) {
-        var matchingLogin = Logins.SingleOrDefault(l => l.Name == login.Name);
+        var matchingLogin =
+          Logins.SingleOrDefault(l => l.Name.Equals(login.Name, StringComparison.InvariantCultureIgnoreCase));
         if(matchingLogin == null)
           new Login(login, this);
       }

--- a/tests/AgDatabaseMove.Integration/Fixtures/TestLoginFixture.cs
+++ b/tests/AgDatabaseMove.Integration/Fixtures/TestLoginFixture.cs
@@ -28,7 +28,8 @@
 
     public void Dispose()
     {
-      _server.Logins.SingleOrDefault(l => l.Name == LoginName)?.Drop();
+      _server.Logins.SingleOrDefault(l => l.Name.Equals(LoginName, StringComparison.InvariantCultureIgnoreCase))
+        ?.Drop();
       _server?.Dispose();
     }
 

--- a/tests/AgDatabaseMove.Integration/TestLogin.cs
+++ b/tests/AgDatabaseMove.Integration/TestLogin.cs
@@ -1,5 +1,6 @@
 ﻿namespace AgDatabaseMove.Integration
 {
+  using System;
   using System.Linq;
   using System.Security.Cryptography;
   using Fixtures;
@@ -38,7 +39,9 @@
     private void TestLoginExists(Login login)
     {
       using(var testServer = _testLoginFixture.ConstructServer()) {
-        var existingLogin = testServer.Logins.SingleOrDefault(l => l.Name == login.Name);
+        var existingLogin =
+          testServer.Logins.SingleOrDefault(l => l.Name.Equals(login.Name,
+                                                               StringComparison.InvariantCultureIgnoreCase));
         Assert.NotNull(existingLogin);
       }
     }

--- a/tests/AgDatabaseMove.Unit/RestoreTests.cs
+++ b/tests/AgDatabaseMove.Unit/RestoreTests.cs
@@ -17,7 +17,7 @@
     }
 
     [Theory]
-    [InlineData("foo", "foo", "foo")]
+    [InlineData("Foo", "foo", "foo")]
     [InlineData("bar", "bar", "master")]
     [InlineData("foo", "bar", "bar")]
     public void DefaultDatabase(string sourceDbName, string destinationDbName, string defaultDb)


### PR DESCRIPTION
SQL Server treats several things as case insensitive, but we were using case sensitive comparisons for them within our application. The replica name in particular caused issues for me.