### PR TITLE
fix(regex): fix regex and cleanup after some testing

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -25,7 +25,7 @@ namespace AgDatabaseMove
     List<BackupMetadata> RecentBackups();
     void JoinAg();
 
-    void Restore(IList<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null);
+    void Restore(IEnumerable<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null);
 
     void CopyLogins(IEnumerable<LoginProperties> logins);
     IEnumerable<LoginProperties> AssociatedLogins();
@@ -88,7 +88,6 @@ namespace AgDatabaseMove
     /// </summary>
     public void LogBackup()
     {
-      // TODO: consider allowing a SQL query for _backupPathTemplate?
       _listener.Primary.LogBackup(Name, _backupPathTemplate);
     }
 
@@ -98,7 +97,7 @@ namespace AgDatabaseMove
     /// </summary>
     /// <param name="backupOrder">An ordered list of backups to restore.</param>
     /// <param name="fileRelocation">A method to generate the new file location when moving the database.</param>
-    public void Restore(IList<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null)
+    public void Restore(IEnumerable<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null)
     {
       _listener.ForEachAgInstance(s => s.Restore(backupOrder, Name, fileRelocation));
     }

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -25,7 +25,7 @@ namespace AgDatabaseMove
     List<BackupMetadata> RecentBackups();
     void JoinAg();
 
-    void Restore(IEnumerable<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null);
+    void Restore(IList<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null);
 
     void CopyLogins(IEnumerable<LoginProperties> logins);
     IEnumerable<LoginProperties> AssociatedLogins();
@@ -88,6 +88,7 @@ namespace AgDatabaseMove
     /// </summary>
     public void LogBackup()
     {
+      // TODO: consider allowing a SQL query for _backupPathTemplate?
       _listener.Primary.LogBackup(Name, _backupPathTemplate);
     }
 
@@ -97,7 +98,7 @@ namespace AgDatabaseMove
     /// </summary>
     /// <param name="backupOrder">An ordered list of backups to restore.</param>
     /// <param name="fileRelocation">A method to generate the new file location when moving the database.</param>
-    public void Restore(IEnumerable<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null)
+    public void Restore(IList<BackupMetadata> backupOrder, Func<string, string> fileRelocation = null)
     {
       _listener.ForEachAgInstance(s => s.Restore(backupOrder, Name, fileRelocation));
     }

--- a/src/AgDatabaseMove.cs
+++ b/src/AgDatabaseMove.cs
@@ -11,6 +11,7 @@ namespace AgDatabaseMove
   using Exceptions;
   using SmoFacade;
 
+
   public class MoveOptions
   {
     public IAgDatabase Source { get; set; }
@@ -53,10 +54,11 @@ namespace AgDatabaseMove
       if(!_options.Overwrite && _options.Destination.Exists() && !_options.Destination.Restoring)
         throw new ArgumentException("Database exists and overwrite option is not set");
 
-      if (lastLsn == null && _options.Destination.Restoring)
-        throw new ArgumentException("lastLsn parameter can only be used if the Destination database is in a restoring state");
+      if(lastLsn == null && _options.Destination.Restoring)
+        throw new
+          ArgumentException("lastLsn parameter can only be used if the Destination database is in a restoring state");
 
-      if (_options.Overwrite)
+      if(_options.Overwrite)
         _options.Destination.Delete();
 
       // TODO: consider making Source DB Single User Mode??
@@ -74,16 +76,15 @@ namespace AgDatabaseMove
 
       _options.Destination.Restore(backupList, _options.FileRelocator);
 
-      if (_options.CopyLogins)
+      if(_options.CopyLogins)
         _options.Destination.CopyLogins(_options.Source.AssociatedLogins().Select(UpdateDefaultDb).ToList());
 
-      if (_options.Finalize)
+      if(_options.Finalize)
         _options.Destination.JoinAg();
-        
+
       _options.Source.Delete();
 
       return backupList.Max(bl => bl.LastLsn);
     }
   }
 }
-

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -15,7 +15,7 @@
 
     public static bool IsUrl(string path)
     {
-      return Regex.IsMatch(path, @"(http(|s):\/)(\/[a-z0-9\.\-]+)+\.([a-zA-Z]+)$");
+      return Regex.IsMatch(path, @"(http(|s):\/)(\/[^\s]+)+\.([a-zA-Z]+)$");
     }
 
     public static string BackupTypeToExtension(BackupType type)

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -96,26 +96,25 @@ namespace AgDatabaseMove.SmoFacade
     /// <param name="backupOrder">An ordered list of backups to apply.</param>
     /// <param name="databaseName">Database to restore to.</param>
     /// <param name="fileRelocation">Option for renaming files during the restore.</param>
-    public void Restore(IList<BackupMetadata> backupOrder, string databaseName, Func<string, string> fileRelocation = null)
+    public void Restore(IEnumerable<BackupMetadata> backupOrder, string databaseName,
+      Func<string, string> fileRelocation = null)
     {
-      var restore = new Restore() { Database = databaseName, NoRecovery = true };
-      
+      var restore = new Restore { Database = databaseName, NoRecovery = true };
+
       foreach(var backup in backupOrder) {
         var device = BackupFileTools.IsUrl(backup.PhysicalDeviceName) ? DeviceType.Url : DeviceType.File;
         var backupDeviceItem = new BackupDeviceItem(backup.PhysicalDeviceName, device);
         restore.Devices.Add(backupDeviceItem);
 
         var defaultFileLocations = DefaultFileLocations();
-        if (defaultFileLocations != null)
-        {
+        if(defaultFileLocations != null) {
           restore.RelocateFiles.Clear();
-          foreach (var file in restore.ReadFileList(_server).AsEnumerable())
-          {
+          foreach(var file in restore.ReadFileList(_server).AsEnumerable()) {
             var physicalName = (string)file["PhysicalName"];
             var fileName = Path.GetFileName(physicalName) ??
                            throw new InvalidBackupException($"Physical name in backup is incomplete: {physicalName}");
 
-            if (fileRelocation != null)
+            if(fileRelocation != null)
               fileName = fileRelocation(fileName);
 
             var path = (string)file["Type"] == "L" ? defaultFileLocations?.Log : defaultFileLocations?.Data;

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -15,7 +15,8 @@ namespace AgDatabaseMove.Unit
       new object[] { "https://a.diff" },
       new object[] { "https://1/2/3/4/5/a.diff" },
       new object[] { "https://storage-account.blob.core.windows.net/container/file.bad" },
-      new object[] { "https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn" },
+      new object[]
+        { "https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn" },
       new object[] { "http://hello/a.bak" }
     };
 

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -15,6 +15,7 @@ namespace AgDatabaseMove.Unit
       new object[] { "https://a.diff" },
       new object[] { "https://1/2/3/4/5/a.diff" },
       new object[] { "https://storage-account.blob.core.windows.net/container/file.bad" },
+      new object[] { "https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn" },
       new object[] { "http://hello/a.bak" }
     };
 


### PR DESCRIPTION
Fixed regex to allow underscores, basically by defining a directory path as anything non-whitespace

Two TODO questions:

1. Should we consider allowing a SQL query for _backupPathTemplate?  Angelo's backups deployement scripts don't update `SMO.Server.BackupDirectory`.  Options to fix would be (1) update that registry value in Angelo's scripts (2) allow CLI option to pass in query for value (3) don't worry about it because the backupPathTemplate should be used
2. Should the source DB be altered to single-user mode prior to the move?  Is that expected to be done by the consuming code?