### PR TITLE
Feat(options): backup path sql query

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -51,16 +51,14 @@ namespace AgDatabaseMove
       Name = dbConfig.DatabaseName;
       _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" });
 
-      if(!string.IsNullOrWhiteSpace(dbConfig.BackupPathSqlQuery)) {
-        using (var cmd = _listener.Primary.SqlConnection.CreateCommand())
-        {
+      if(!string.IsNullOrWhiteSpace(dbConfig.BackupPathSqlQuery))
+        using(var cmd = _listener.Primary.SqlConnection.CreateCommand()) {
           cmd.CommandText = dbConfig.BackupPathSqlQuery;
-          using (var reader = cmd.ExecuteReader()) {
+          using(var reader = cmd.ExecuteReader()) {
             if(reader.Read())
               _backupPathTemplate = (string)reader[0];
           }
         }
-      }
     }
 
     /// <summary>

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -39,7 +39,7 @@ namespace AgDatabaseMove
   /// </summary>
   public class AgDatabase : IDisposable, IAgDatabase
   {
-    private readonly string _backupPathTemplate;
+    private readonly string _backupPathSqlQuery;
     internal readonly IListener _listener;
 
     /// <summary>
@@ -49,16 +49,8 @@ namespace AgDatabaseMove
     public AgDatabase(DatabaseConfig dbConfig)
     {
       Name = dbConfig.DatabaseName;
+      _backupPathSqlQuery = dbConfig.BackupPathSqlQuery;
       _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" });
-
-      if(!string.IsNullOrWhiteSpace(dbConfig.BackupPathSqlQuery))
-        using(var cmd = _listener.Primary.SqlConnection.CreateCommand()) {
-          cmd.CommandText = dbConfig.BackupPathSqlQuery;
-          using(var reader = cmd.ExecuteReader()) {
-            if(reader.Read())
-              _backupPathTemplate = (string)reader[0];
-          }
-        }
     }
 
     /// <summary>
@@ -96,7 +88,7 @@ namespace AgDatabaseMove
     /// </summary>
     public void LogBackup()
     {
-      _listener.Primary.LogBackup(Name, _backupPathTemplate);
+      _listener.Primary.LogBackup(Name, _backupPathSqlQuery);
     }
 
     /// <summary>
@@ -156,7 +148,7 @@ namespace AgDatabaseMove
 
     public void FullBackup()
     {
-      _listener.Primary.FullBackup(Name, _backupPathTemplate);
+      _listener.Primary.FullBackup(Name, _backupPathSqlQuery);
     }
 
     private void WaitForInitialization(Server server, AvailabilityGroup availabilityGroup)

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -50,7 +50,17 @@ namespace AgDatabaseMove
     {
       Name = dbConfig.DatabaseName;
       _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" });
-      _backupPathTemplate = dbConfig.BackupPathTemplate;
+
+      if(!string.IsNullOrWhiteSpace(dbConfig.BackupPathSqlQuery)) {
+        using (var cmd = _listener.Primary.SqlConnection.CreateCommand())
+        {
+          cmd.CommandText = dbConfig.BackupPathSqlQuery;
+          using (var reader = cmd.ExecuteReader()) {
+            if(reader.Read())
+              _backupPathTemplate = (string)reader[0];
+          }
+        }
+      }
     }
 
     /// <summary>

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -21,8 +21,8 @@
     /// <summary>
     ///   SQL query text to retrieve the desired backup path location. If none is provided, Server.DefaultBackupPathTemplate is
     ///   used.   See <see cref="Server.DefaultBackupPathTemplate" />
-    /// <example> SELECT '\\my\backup\location\'</example>
-    /// <example> SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]</example>
+    ///   <example> SELECT '\\my\backup\location\'</example>
+    ///   <example> SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]</example>
     /// </summary>
     public string BackupPathSqlQuery { get; set; } = "SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]";
   }

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -24,6 +24,6 @@
     ///   <example> SELECT '\\my\backup\location\'</example>
     ///   <example> SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]</example>
     /// </summary>
-    public string BackupPathSqlQuery { get; set; } = "SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]";
+    public string BackupPathSqlQuery { get; set; }
   }
 }

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -19,9 +19,11 @@
     public string DatabaseName { get; set; }
 
     /// <summary>
-    ///   If this isn't supplied we build one from the database default backup path.
-    ///   See <see cref="Server.DefaultBackupPathTemplate" />
+    ///   SQL query text to retrieve the desired backup path location. If none is provided, Server.DefaultBackupPathTemplate is
+    ///   used.   See <see cref="Server.DefaultBackupPathTemplate" />
+    /// <example> SELECT '\\my\backup\location\'</example>
+    /// <example> SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]</example>
     /// </summary>
-    public string BackupPathTemplate { get; set; }
+    public string BackupPathSqlQuery { get; set; } = "SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]";
   }
 }

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -143,7 +143,7 @@ namespace AgDatabaseMove.SmoFacade
     /// </param>
     public void LogBackup(string databaseName, string backupDirectoryPath = null)
     {
-      backupDirectoryPath = backupDirectoryPath ?? DefaultBackupDirectoryPath();
+      backupDirectoryPath = backupDirectoryPath ?? _server.BackupDirectory;
       var backup = new Backup
         { Action = BackupActionType.Log, Database = databaseName, LogTruncation = BackupTruncateLogType.Truncate };
       Backup(backup, backupDirectoryPath, databaseName, BackupFileTools.BackupType.Log);
@@ -161,7 +161,7 @@ namespace AgDatabaseMove.SmoFacade
     /// </param>
     public void FullBackup(string databaseName, string backupDirectoryPath = null)
     {
-      backupDirectoryPath = backupDirectoryPath ?? DefaultBackupDirectoryPath();
+      backupDirectoryPath = backupDirectoryPath ?? _server.BackupDirectory;
       var backup = new Backup {
         Action = BackupActionType.Database, Database = databaseName, LogTruncation = BackupTruncateLogType.NoTruncate
       };
@@ -173,21 +173,13 @@ namespace AgDatabaseMove.SmoFacade
       if(backupDirectoryPath.EndsWith("\\") || backupDirectoryPath.EndsWith("/"))
         backupDirectoryPath = backupDirectoryPath.Substring(0, backupDirectoryPath.Length - 1);
 
-      var filePath = $"{backupDirectoryPath}/{databaseName}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
+      var filePath =
+        $"{backupDirectoryPath}/{databaseName}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
       var deviceType = BackupFileTools.IsUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);
       backup.Devices.Add(bdi);
       backup.SqlBackup(_server);
-    }
-    
-    /// <summary>
-    ///   Builds a backup path template from the server's default backup directory.
-    ///   If this path is not valid on the destination instance the restore process will fail.
-    /// </summary>
-    private string DefaultBackupDirectoryPath()
-    {
-      return _server.BackupDirectory;
     }
 
     public void EnsureLogins(IEnumerable<LoginProperties> newLogins)

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -83,7 +83,7 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     /// <summary>
-    ///   Runs SQL query to obtain backup location
+    ///   Runs SQL query to obtain backup location 
     ///   If query is null or empty _server.BackupDirectory is used
     /// </summary>
     /// <param name="backupDirectoryQuery"></param>

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -143,7 +143,6 @@ namespace AgDatabaseMove.SmoFacade
     /// </param>
     public void LogBackup(string databaseName, string backupDirectoryPath = null)
     {
-      backupDirectoryPath = backupDirectoryPath ?? _server.BackupDirectory;
       var backup = new Backup
         { Action = BackupActionType.Log, Database = databaseName, LogTruncation = BackupTruncateLogType.Truncate };
       Backup(backup, backupDirectoryPath, databaseName, BackupFileTools.BackupType.Log);
@@ -161,7 +160,6 @@ namespace AgDatabaseMove.SmoFacade
     /// </param>
     public void FullBackup(string databaseName, string backupDirectoryPath = null)
     {
-      backupDirectoryPath = backupDirectoryPath ?? _server.BackupDirectory;
       var backup = new Backup {
         Action = BackupActionType.Database, Database = databaseName, LogTruncation = BackupTruncateLogType.NoTruncate
       };
@@ -170,6 +168,7 @@ namespace AgDatabaseMove.SmoFacade
 
     private void Backup(Backup backup, string backupDirectoryPath, string databaseName, BackupFileTools.BackupType type)
     {
+      backupDirectoryPath = backupDirectoryPath ?? _server.BackupDirectory;
       if(backupDirectoryPath.EndsWith("\\") || backupDirectoryPath.EndsWith("/"))
         backupDirectoryPath = backupDirectoryPath.Substring(0, backupDirectoryPath.Length - 1);
 

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -83,8 +83,8 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     /// <summary>
-    /// Runs SQL query to obtain backup location
-    /// If query is null or empty _server.BackupDirectory is used
+    ///   Runs SQL query to obtain backup location
+    ///   If query is null or empty _server.BackupDirectory is used
     /// </summary>
     /// <param name="backupDirectoryQuery"></param>
     /// <returns></returns>
@@ -92,20 +92,16 @@ namespace AgDatabaseMove.SmoFacade
     {
       string result = null;
       if(!string.IsNullOrWhiteSpace(backupDirectoryQuery))
-      {
-        using (var cmd = SqlConnection.CreateCommand())
-        {
+        using(var cmd = SqlConnection.CreateCommand()) {
           cmd.CommandText = backupDirectoryQuery;
-          using (var reader = cmd.ExecuteReader())
-          {
-            if (reader.Read())
+          using(var reader = cmd.ExecuteReader()) {
+            if(reader.Read())
               result = (string)reader[0];
           }
         }
-      }
-      
+
       result = result ?? _server.BackupDirectory;
-      if (result.EndsWith("\\") || result.EndsWith("/"))
+      if(result.EndsWith("\\") || result.EndsWith("/"))
         result = result.Substring(0, result.Length - 1);
 
       return result;
@@ -195,7 +191,8 @@ namespace AgDatabaseMove.SmoFacade
       Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Full);
     }
 
-    private void Backup(Backup backup, string backupDirectoryPathQuery, string databaseName, BackupFileTools.BackupType type)
+    private void Backup(Backup backup, string backupDirectoryPathQuery, string databaseName,
+      BackupFileTools.BackupType type)
     {
       var backupDirectory = BackupDirectoryOrDefault(backupDirectoryPathQuery);
       var filePath =

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -83,7 +83,7 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     /// <summary>
-    ///   Runs SQL query to obtain backup location 
+    ///   Runs SQL query to obtain backup location
     ///   If query is null or empty _server.BackupDirectory is used
     /// </summary>
     /// <param name="backupDirectoryQuery"></param>

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -89,14 +89,13 @@ namespace AgDatabaseMove.SmoFacade
     private string BackupDirectoryOrDefault(string backupDirectoryQuery)
     {
       string result = null;
-      if(!string.IsNullOrWhiteSpace(backupDirectoryQuery))
-        using(var cmd = SqlConnection.CreateCommand()) {
-          cmd.CommandText = backupDirectoryQuery;
-          using(var reader = cmd.ExecuteReader()) {
-            if(reader.Read())
-              result = (string)reader[0];
-          }
-        }
+      if(!string.IsNullOrWhiteSpace(backupDirectoryQuery)) {
+        using var cmd = SqlConnection.CreateCommand();
+        cmd.CommandText = backupDirectoryQuery;
+        using var reader = cmd.ExecuteReader();
+        if(reader.Read())
+          result = (string)reader[0];
+      }
 
       result = result ?? _server.BackupDirectory;
       if(result.EndsWith("\\") || result.EndsWith("/"))


### PR DESCRIPTION
Instead of passing in a string of the backup path template, pass in a string that is a SQL query to fetch the location.
If no text is present, then the fallback is `_server.BackupDirectory`

The query allows more flexibility on where consumers store their backup paths.

Note: the default value for `BackupPathSqlQuery` could probably be removed as that's more CRDS specific