### PR TITLE
feat(cred): explicit credential name

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -51,7 +51,8 @@ namespace AgDatabaseMove
     {
       Name = dbConfig.DatabaseName;
       _backupPathSqlQuery = dbConfig.BackupPathSqlQuery;
-      _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" }, dbConfig.CredentialName);
+      _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" },
+                               dbConfig.CredentialName);
     }
 
     /// <summary>

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -51,7 +51,7 @@ namespace AgDatabaseMove
     {
       Name = dbConfig.DatabaseName;
       _backupPathSqlQuery = dbConfig.BackupPathSqlQuery;
-      _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" });
+      _listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" }, dbConfig.CredentialName);
     }
 
     /// <summary>

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -26,6 +26,11 @@
     /// </summary>
     public string BackupPathSqlQuery { get; set; }
 
+    /// <summary>
+    /// Server credential used for backup and restore operations. Necessary for SqlServer 2012 and older
+    /// </summary>
+    public string CredentialName { get; set; }
+
     public override string ToString()
     {
       return $"{ConnectionString}\n{DatabaseName}\n{BackupPathSqlQuery}\n";

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -27,7 +27,7 @@
     public string BackupPathSqlQuery { get; set; }
 
     /// <summary>
-    /// Server credential used for backup and restore operations. Necessary for SqlServer 2012 and older
+    ///   Server credential used for backup and restore operations. Necessary for SqlServer 2012 and older
     /// </summary>
     public string CredentialName { get; set; }
 

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -50,7 +50,7 @@ namespace AgDatabaseMove.SmoFacade
      * connection to find those server names though is done through the listener and that instance is thrown away in this
      * constructor so it won't be used again.
      */
-    public Listener(SqlConnectionStringBuilder connectionStringBuilder)
+    public Listener(SqlConnectionStringBuilder connectionStringBuilder, string credentailName = null)
     {
       if(connectionStringBuilder.DataSource == null)
         throw new ArgumentException("DataSource not supplied in connection string");
@@ -69,12 +69,12 @@ namespace AgDatabaseMove.SmoFacade
       var secondaryNames = availabilityGroup.Replicas.Where(l => l != primaryName);
 
       // Connect to each server instance
-      Primary = AgListenerNameToServer(ref connectionStringBuilder, primaryName);
+      Primary = AgListenerNameToServer(ref connectionStringBuilder, primaryName, credentailName);
       AvailabilityGroup = Primary.AvailabilityGroups.Single(ag => ag.Name == availabilityGroup.Name);
 
       _secondaries = new List<Server>();
       foreach(var secondaryName in secondaryNames)
-        _secondaries.Add(AgListenerNameToServer(ref connectionStringBuilder, secondaryName));
+        _secondaries.Add(AgListenerNameToServer(ref connectionStringBuilder, secondaryName, credentailName));
     }
 
     public IEnumerable<Server> ReplicaInstances => Secondaries.Union(new[] { Primary });
@@ -128,10 +128,10 @@ namespace AgDatabaseMove.SmoFacade
       return dotIndex >= 0 ? dataSource.Remove(dotIndex) : dataSource;
     }
 
-    private static Server AgListenerNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName)
+    private static Server AgListenerNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName, string credentailName)
     {
       connBuilder.DataSource = Dns.GetHostEntry(agInstanceName).HostName;
-      return new Server(connBuilder.ToString());
+      return new Server(connBuilder.ToString(), credentailName);
     }
   }
 }

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -128,7 +128,8 @@ namespace AgDatabaseMove.SmoFacade
       return dotIndex >= 0 ? dataSource.Remove(dotIndex) : dataSource;
     }
 
-    private static Server AgListenerNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName, string credentailName)
+    private static Server AgListenerNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName,
+      string credentailName)
     {
       connBuilder.DataSource = Dns.GetHostEntry(agInstanceName).HostName;
       return new Server(connBuilder.ToString(), credentailName);

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -16,8 +16,8 @@ namespace AgDatabaseMove.SmoFacade
   /// </summary>
   public class Server : IDisposable
   {
-    internal readonly Microsoft.SqlServer.Management.Smo.Server _server;
     internal readonly string _credentialName;
+    internal readonly Microsoft.SqlServer.Management.Smo.Server _server;
 
     public Server(string connectionString, string credentialName = null)
     {
@@ -205,7 +205,7 @@ namespace AgDatabaseMove.SmoFacade
       var deviceType = BackupFileTools.IsUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);
-      if (_credentialName != null && deviceType == DeviceType.Url)
+      if(_credentialName != null && deviceType == DeviceType.Url)
         bdi.CredentialName = _credentialName;
 
       backup.Devices.Add(bdi);


### PR DESCRIPTION
SqlServer <= 2012 doesn't support SAS tokens for backup/restore operations. 
Credential name is required in this case
https://docs.microsoft.com/en-us/sql/relational-databases/backup-restore/sql-server-backup-to-url?view=sql-server-ver15#sqlserver