### PR TITLE
fix(linux_dns_issue): Re-trying DNS lookup of instance name after appending the domain from AG listener

### DIFF
--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -5,8 +5,7 @@ namespace AgDatabaseMove.SmoFacade
   using System.Data.SqlClient;
   using System.Linq;
   using System.Net;
-    using System.Runtime.InteropServices;
-    using System.Threading.Tasks;
+  using System.Threading.Tasks;
 
 
   internal interface IListener : IDisposable
@@ -146,16 +145,23 @@ namespace AgDatabaseMove.SmoFacade
       return new Server(connBuilder.ToString(), credentialName);
     }
 
-    private static string ResolveDnsAndGetHostName(string hostUrl, string instance)
+    /// <summary>
+    ///   Resolves "instanceName" to a FQDNS name
+    ///   However on Unix OS, "instanceName" should be a complete domain - "{sub domain}.{second level domain}.{...}.{top level domain}" (eg: "xyz.abc.def.com")
+    ///   Therefore, append from the {second-level} -> {top-level} domains from the "hostDomain" to the "instanceName" to make it a complete domain if it is not already
+    /// </summary>
+    /// <param name="hostDomain">The complete domain for the SQL server</param>
+    /// <param name="instanceName">The specific name of an instance within the server</param>
+    private static string ResolveDnsAndGetHostName(string hostDomain, string instanceName)
     {
-      if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && !instance.Contains('.'))
+      if (Environment.OSVersion.Platform == PlatformID.Unix && !instanceName.Contains('.'))
       {
-        string[] urlFragments = hostUrl.Split('.');
-        urlFragments[0] = "";
-        instance += string.Join(".", urlFragments);
+        string[] domainFragments = hostDomain.Split('.');
+        domainFragments[0] = "";
+        instanceName += string.Join(".", domainFragments);
       }
-      var res = Dns.GetHostEntry(instance).HostName;
-      return res;
+      return Dns.GetHostEntry(instanceName).HostName;
+
     }
   }
 }

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -134,13 +134,13 @@ namespace AgDatabaseMove.SmoFacade
       string credentialName)
     {
       var parts = agInstanceName.Split('\\');
-        if(parts.Length == 1)
-          connBuilder.DataSource = ResolveDnsAndGetHostName(connBuilder.DataSource, agInstanceName);
-        else if(parts.Length == 2)
-          // NamedInstances: chop instance name, resolve DNS, slap instance name back on!
-          connBuilder.DataSource = $"{ResolveDnsAndGetHostName(connBuilder.DataSource, parts[0])}\\{parts[1]}";
-        else
-          throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS");
+      if(parts.Length == 1)
+        connBuilder.DataSource = ResolveDnsAndGetHostName(connBuilder.DataSource, agInstanceName);
+      else if(parts.Length == 2)
+        // NamedInstances: chop instance name, resolve DNS, slap instance name back on!
+        connBuilder.DataSource = $"{ResolveDnsAndGetHostName(connBuilder.DataSource, parts[0])}\\{parts[1]}";
+      else
+        throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS");
 
       return new Server(connBuilder.ToString(), credentialName);
     }

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Data.SqlClient;
-using System.Linq;
-using System.Net;
-using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
-
-[assembly: InternalsVisibleTo("AgDatabaseMove.Unit")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("AgDatabaseMove.Unit")]
 namespace AgDatabaseMove.SmoFacade
 {
+  using System;
+  using System.Collections.Generic;
+  using System.Data.SqlClient;
+  using System.Linq;
+  using System.Net;
+  using System.Threading.Tasks;
+
   internal interface IListener : IDisposable
   {
     /// <summary>

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -146,37 +146,37 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     /// <summary>
-    ///   Resolves "instanceName" to a FQDNS name
-    ///   However on Unix OS, "instanceName" should be a complete domain - "{sub domain}.{second level domain}.{...}.{top level domain}" (eg: "xyz.abc.def.com")
-    ///   Therefore, append from the {second-level} -> {top-level} domains from the "hostDomain" to the "instanceName" to make it a complete domain if it is not already
+    ///   Resolves "agReplicaInstanceName" to a FQDNS name
+    ///   However on Unix OS, "agReplicaInstanceName" should be a complete domain - "{sub domain}.{second level domain}.{...}.{top level domain}" (eg: "xyz.abc.def.com")
+    ///   Therefore, we use {second-level} -> {top-level} part of the domain from "agListenerDomain" and append it to "agReplicaInstanceName"
     /// </summary>
-    /// <param name="hostDomain">The complete domain for the SQL server</param>
-    /// <param name="instanceName">The specific name of an instance within the server</param>
-    private static string ResolveDnsAndGetHostName(string hostDomain, string instanceName)
+    /// <param name="agListenerDomain">The complete domain for the SQL server AG listener</param>
+    /// <param name="agReplicaInstanceName">The specific name of a replica instance within the AG</param>
+    private static string ResolveDnsAndGetHostName(string agListenerDomain, string agReplicaInstanceName)
     {
-      Tuple<string, string> domain_port = SplitDomainPort(hostDomain);
-      if (Environment.OSVersion.Platform == PlatformID.Unix && !instanceName.Contains('.'))
+      Tuple<string, string> domain_port = SplitDomainPort(agListenerDomain);
+      if (Environment.OSVersion.Platform == PlatformID.Unix)
       {
         string[] domainFragments = domain_port.Item1.Split('.');
         domainFragments[0] = "";
-        instanceName += string.Join(".", domainFragments);
+        agReplicaInstanceName += string.Join(".", domainFragments);
       }
-      return Dns.GetHostEntry(instanceName).HostName+domain_port.Item2;
+      return Dns.GetHostEntry(agReplicaInstanceName).HostName+domain_port.Item2;
 
     }
-    private static Tuple<string,string> SplitDomainPort(string hostDomain)
+    private static Tuple<string,string> SplitDomainPort(string domainAndPort)
     {
-      string domian = hostDomain;
+      string domian = domainAndPort;
       string port = "";
-      if (hostDomain.Contains(','))
+      if (domainAndPort.Contains(','))
       {
-        string[] fragments = hostDomain.Split(new char[] {','}, 2);
+        string[] fragments = domainAndPort.Split(new char[] {','}, 2);
         domian = fragments[0];
         port = ","+fragments[1];
       }
-      else if (hostDomain.Contains('\\'))
+      else if (domainAndPort.Contains('\\'))
       {
-        string[] fragments = hostDomain.Split(new char[] {'\\'}, 2);
+        string[] fragments = domainAndPort.Split(new char[] {'\\'}, 2);
         domian = fragments[0];
         port = "\\"+fragments[1];
       }

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -177,20 +177,16 @@ namespace AgDatabaseMove.SmoFacade
       }
     }
 
-    // first preference is to add back port over named instance (NI) 
+    // First preference is to add back a port over a named instance (NI) 
     // (port is TCP/IP standard while named instance is only SQL Server standard)
-    // If both are same, prioritize 'instancePortOrNi' over 'listenerPortOrNi' (in almost all cases they should be identical)
+    // If both are same type, then prioritize instance over listener (in almost all cases they should be identical)
     internal static string GetPreferredPort(string instancePortOrNi, string listenerPortOrNi)
     {
       if (string.IsNullOrEmpty(instancePortOrNi) || string.IsNullOrEmpty(listenerPortOrNi))
       {
         return (instancePortOrNi ?? listenerPortOrNi);
       }
-      if (instancePortOrNi.StartsWith("\\"))
-      {
-        return (listenerPortOrNi.StartsWith(",") ? listenerPortOrNi : instancePortOrNi);
-      }
-      return instancePortOrNi;
+      return instancePortOrNi.StartsWith("\\") && listenerPortOrNi.StartsWith(",") ? listenerPortOrNi : instancePortOrNi;
     }
 
     // This function handles named instances ("<domain>\<named instance>") in the same way as ports

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -1,13 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+[assembly: InternalsVisibleTo("AgDatabaseMove.Unit")]
 namespace AgDatabaseMove.SmoFacade
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Data.SqlClient;
-  using System.Linq;
-  using System.Net;
-  using System.Threading.Tasks;
-
-
   internal interface IListener : IDisposable
   {
     /// <summary>
@@ -178,7 +179,7 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     // This function handles named instances ("<domain>\<named instance>") in the same way as ports
-    private static (string, string) SplitDomainAndPort(string domainAndPort)
+    internal static (string, string) SplitDomainAndPort(string domainAndPort)
     {
       var domain = domainAndPort;
       var splitValue = domainAndPort.Contains(',') ? "," : domainAndPort.Contains('\\') ? "\\" : null;

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -154,14 +154,33 @@ namespace AgDatabaseMove.SmoFacade
     /// <param name="instanceName">The specific name of an instance within the server</param>
     private static string ResolveDnsAndGetHostName(string hostDomain, string instanceName)
     {
+      Tuple<string, string> domain_port = SplitDomainPort(hostDomain);
       if (Environment.OSVersion.Platform == PlatformID.Unix && !instanceName.Contains('.'))
       {
-        string[] domainFragments = hostDomain.Split('.');
+        string[] domainFragments = domain_port.Item1.Split('.');
         domainFragments[0] = "";
         instanceName += string.Join(".", domainFragments);
       }
-      return Dns.GetHostEntry(instanceName).HostName;
+      return Dns.GetHostEntry(instanceName).HostName+domain_port.Item2;
 
+    }
+    private static Tuple<string,string> SplitDomainPort(string hostDomain)
+    {
+      string domian = hostDomain;
+      string port = "";
+      if (hostDomain.Contains(','))
+      {
+        string[] fragments = hostDomain.Split(new char[] {','}, 2);
+        domian = fragments[0];
+        port = ","+fragments[1];
+      }
+      else if (hostDomain.Contains('\\'))
+      {
+        string[] fragments = hostDomain.Split(new char[] {'\\'}, 2);
+        domian = fragments[0];
+        port = "\\"+fragments[1];
+      }
+      return new Tuple<string, string>(domian, port);
     }
   }
 }

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -134,13 +134,13 @@ namespace AgDatabaseMove.SmoFacade
       string credentialName)
     {
       var parts = agInstanceName.Split('\\');
-            if (parts.Length == 1)
-                connBuilder.DataSource = ResolveDnsAndGetHostName(connBuilder.DataSource, agInstanceName);
-            else if (parts.Length == 2)
-                // NamedInstances: chop instance name, resolve DNS, slap instance name back on!
-                connBuilder.DataSource = $"{ResolveDnsAndGetHostName(connBuilder.DataSource, parts[0])}\\{parts[1]}";
-            else
-                throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS");
+        if(parts.Length == 1)
+          connBuilder.DataSource = ResolveDnsAndGetHostName(connBuilder.DataSource, agInstanceName);
+        else if(parts.Length == 2)
+          // NamedInstances: chop instance name, resolve DNS, slap instance name back on!
+          connBuilder.DataSource = $"{ResolveDnsAndGetHostName(connBuilder.DataSource, parts[0])}\\{parts[1]}";
+        else
+          throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS");
 
       return new Server(connBuilder.ToString(), credentialName);
     }

--- a/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
+++ b/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
@@ -5,18 +5,23 @@ namespace AgDatabaseMove.Unit
 {
   public class SmoFacadeListenerTest
   {
+
+    /// <summary>
+    /// Tests for Listener.SplitDomainAndPort()
+    /// </summary>
+
     private const string DOMAIN = "abc.def.ghi";
     private const string HOST = "abc";
 
     // {input, expectedDomain, expectedPort (can be null)}
     public static IEnumerable<object[]> ValidPorts => new List<object[]> {
-      new object[] {$"{DOMAIN}", DOMAIN},
-      new object[] {$"{DOMAIN},123", DOMAIN, ",123" },
-      new object[] {$"{DOMAIN}\\SQL", DOMAIN, "\\SQL" },
+      new object[] { $"{DOMAIN}", DOMAIN },
+      new object[] { $"{DOMAIN},123", DOMAIN, ",123" },
+      new object[] { $"{DOMAIN}\\SQL", DOMAIN, "\\SQL" },
 
-      new object[] {$"{HOST}", HOST},
-      new object[] {$"{HOST},123", HOST, ",123" },
-      new object[] {$"{HOST}\\SQL", HOST, "\\SQL" }
+      new object[] { $"{HOST}", HOST },
+      new object[] { $"{HOST},123", HOST, ",123" },
+      new object[] { $"{HOST}\\SQL", HOST, "\\SQL" }
     };
 
     [Theory]
@@ -30,11 +35,11 @@ namespace AgDatabaseMove.Unit
 
     // {input, expectedDomain, expectedPort (can be null)}
     public static IEnumerable<object[]> InvalidPorts => new List<object[]> {
-      new object[] {$"{DOMAIN}:123", $"{DOMAIN}:123" },
-      new object[] {$"{DOMAIN}:SQL", $"{DOMAIN}:SQL" },
+      new object[] { $"{DOMAIN}:123", $"{DOMAIN}:123" },
+      new object[] { $"{DOMAIN}:SQL", $"{DOMAIN}:SQL" },
 
-      new object[] {$"{HOST}:123", $"{HOST}:123" },
-      new object[] {$"{HOST}:SQL", $"{HOST}:SQL" },
+      new object[] { $"{HOST}:123", $"{HOST}:123" },
+      new object[] { $"{HOST}:SQL", $"{HOST}:SQL" },
     };
 
     [Theory]
@@ -45,5 +50,37 @@ namespace AgDatabaseMove.Unit
       Assert.Equal(domain, expectedDomain);
       Assert.Equal(port, expectedPort);
     }
+
+
+    /// <summary>
+    /// Tests for Listener.GetPreferredPort()
+    /// </summary>
+
+    private const string IPort = ",123";
+    private const string INamed = "\\SQL";
+
+    private const string LPort = ",321";
+    private const string LNamed = "\\LQS";
+    // { instancePort,  listenerPort,  preferredPort}
+    public static IEnumerable<object[]> PortPreferences => new List<object[]> {
+      new object[] { null   , null   , null},
+      new object[] { null   , LPort  , LPort},
+      new object[] { null   , LNamed , LNamed},
+      new object[] { IPort  , null   , IPort},
+      new object[] { IPort  , LPort  , IPort},
+      new object[] { IPort  , LNamed , IPort},
+      new object[] { INamed , null   , INamed},
+      new object[] { INamed , LPort  , LPort},
+      new object[] { INamed , LNamed , INamed},
+    };
+
+    [Theory]
+    [MemberData(nameof(PortPreferences))]
+    public void PortPreferenceTests(string instancePort=null, string listenerPort=null, string preferredPort=null)
+    {
+      var port = SmoFacade.Listener.GetPreferredPort(instancePort, listenerPort);
+      Assert.Equal(port, preferredPort);
+    }
+
   }
 }

--- a/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
+++ b/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace AgDatabaseMove.Unit
+{
+  public class SmoFacadeListenerTest
+  {
+    private const string DOMAIN = "abc.def.ghi";
+    private const string HOST = "abc";
+
+    // {input, expectedDomain, expectedPort (can be null)}
+    public static IEnumerable<object[]> ValidPorts => new List<object[]> {
+      new object[] {$"{DOMAIN}", DOMAIN},
+      new object[] {$"{DOMAIN},123", DOMAIN, ",123" },
+      new object[] {$"{DOMAIN}\\SQL", DOMAIN, "\\SQL" },
+
+      new object[] {$"{HOST}", HOST},
+      new object[] {$"{HOST},123", HOST, ",123" },
+      new object[] {$"{HOST}\\SQL", HOST, "\\SQL" }
+    };
+
+    [Theory]
+    [MemberData(nameof(ValidPorts))]
+    public void ValidPortTests(string input, string expectedDomain, string expectedPort=null)
+    {
+      var (domain, port) = SmoFacade.Listener.SplitDomainAndPort(input);
+      Assert.Equal(domain, expectedDomain);
+      Assert.Equal(port, expectedPort);
+    }
+
+    // {input, expectedDomain, expectedPort (can be null)}
+    public static IEnumerable<object[]> InvalidPorts => new List<object[]> {
+      new object[] {$"{DOMAIN}:123", $"{DOMAIN}:123" },
+      new object[] {$"{DOMAIN}:SQL", $"{DOMAIN}:SQL" },
+
+      new object[] {$"{HOST}:123", $"{HOST}:123" },
+      new object[] {$"{HOST}:SQL", $"{HOST}:SQL" },
+    };
+
+    [Theory]
+    [MemberData(nameof(InvalidPorts))]
+    public void InvalidPortTests(string input, string expectedDomain, string expectedPort=null)
+    {
+      var (domain, port) = SmoFacade.Listener.SplitDomainAndPort(input);
+      Assert.Equal(domain, expectedDomain);
+      Assert.Equal(port, expectedPort);
+    }
+  }
+}


### PR DESCRIPTION
`Dns.GetHostEntry(instance)` fails intermittently on linux platforms if `instance` doesn't have the full domain
