### PR TITLE
fix(striped_backups): changed logic to get all striped backups

### DIFF
--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -76,7 +76,9 @@ namespace AgDatabaseMove
         .Where(b => b.BackupType == BackupFileTools.BackupType.Diff &&
                     b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn)
         .OrderByDescending(b => b.LastLsn).ToList();
-
+      if (!diffBackupsOrdered.Any()) {
+        return new List<BackupMetadata>();
+      }
       var targetLastLsn = diffBackupsOrdered.First().LastLsn;
       // get all the stripes of this backup
       return diffBackupsOrdered.Where(diffBackup => diffBackup.LastLsn == targetLastLsn); 

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -23,7 +23,7 @@ namespace AgDatabaseMove
     // This also handles any striped backups
     private BackupChain(IList<BackupMetadata> recentBackups)
     {
-      if (!(recentBackups?.Count > 0)) {
+      if (recentBackups == null || recentBackups.Count == 0) {
         throw new BackupChainException("There are no recent backups to form a chain");
       }
 

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -32,7 +32,7 @@ namespace AgDatabaseMove
         .Where(IsValidFilePath) // A third party application caused invalid path strings to be inserted into backupmediafamily
         .ToList();
 
-      var mostRecentFullBackups = MostRecentFullBackups(recentBackups).ToList();
+      var mostRecentFullBackups = MostRecentFullBackups(backups).ToList();
       
       var differentialBackups = MostRecentDifferentialBackups(backups, mostRecentFullBackups.First());
       // differentialBackups can be null

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -76,6 +76,7 @@ namespace AgDatabaseMove
         .Where(b => b.BackupType == BackupFileTools.BackupType.Diff &&
                     b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn)
         .OrderByDescending(b => b.LastLsn).ToList();
+
       if (!diffBackupsOrdered.Any()) {
         return new List<BackupMetadata>();
       }

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -23,6 +23,10 @@ namespace AgDatabaseMove
     // This also handles any striped backups
     private BackupChain(IList<BackupMetadata> recentBackups)
     {
+      if (!recentBackups.Any()) {
+        throw new BackupChainException("There are no recent backups to form a chain");
+      }
+
       var backups = recentBackups.Distinct(new BackupMetadataEqualityComparer())
         .Where(IsValidFilePath) // A third party application caused invalid path strings to be inserted into backupmediafamily
         .ToList();

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -23,7 +23,7 @@ namespace AgDatabaseMove
     // This also handles any striped backups
     private BackupChain(IList<BackupMetadata> recentBackups)
     {
-      if (recentBackups == null || !recentBackups.Any()) {
+      if (!(recentBackups?.Count > 0)) {
         throw new BackupChainException("There are no recent backups to form a chain");
       }
 

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -23,7 +23,7 @@ namespace AgDatabaseMove
     // This also handles any striped backups
     private BackupChain(IList<BackupMetadata> recentBackups)
     {
-      if (!recentBackups.Any()) {
+      if (recentBackups == null || !recentBackups.Any()) {
         throw new BackupChainException("There are no recent backups to form a chain");
       }
 

--- a/src/BackupMetadata.cs
+++ b/src/BackupMetadata.cs
@@ -17,13 +17,15 @@ namespace AgDatabaseMove
       return x.LastLsn == y.LastLsn &&
              x.FirstLsn == y.FirstLsn &&
              x.BackupType == y.BackupType &&
-             x.DatabaseName == y.DatabaseName;
+             x.DatabaseName == y.DatabaseName &&
+             x.PhysicalDeviceName == y.PhysicalDeviceName;
     }
 
     public int GetHashCode(BackupMetadata obj)
     {
       var hashCode = -1277603921;
       hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.DatabaseName);
+      hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
       hashCode = hashCode * -1521134295 +
                  EqualityComparer<BackupFileTools.BackupType>.Default.GetHashCode(obj.BackupType);
       hashCode = hashCode * -1521134295 + obj.FirstLsn.GetHashCode();

--- a/src/BackupMetadata.cs
+++ b/src/BackupMetadata.cs
@@ -37,7 +37,7 @@ namespace AgDatabaseMove
   /// <summary>
   ///   Metadata about backups from msdb.dbo.backupset and msdb.dbo.backupmediafamily
   /// </summary>
-  public class BackupMetadata
+  public class BackupMetadata : ICloneable
   {
     public decimal CheckpointLsn { get; set; }
     public decimal DatabaseBackupLsn { get; set; }
@@ -54,5 +54,11 @@ namespace AgDatabaseMove
     ///   https://docs.microsoft.com/en-us/sql/relational-databases/system-tables/backupset-transact-sql?view=sql-server-2017
     /// </summary>
     public BackupFileTools.BackupType BackupType { get; set; }
+
+    // used during testing
+    public object Clone()
+    {
+      return MemberwiseClone();
+    }
   }
 }

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -12,10 +12,10 @@ namespace AgDatabaseMove.Unit
   public class BackupOrder
   {
 
-    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> baseList)
+    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
     {
       var result = new List<BackupMetadata>();
-      baseList.ForEach(b => {
+      list.ForEach(b => {
         result.Add((BackupMetadata)b.Clone());
       });
       result.Reverse();
@@ -191,7 +191,7 @@ namespace AgDatabaseMove.Unit
       var backupChain = new BackupChain(agDatabase.Object);
       VerifyListIsAValidBackupChain(backupChain.OrderedBackups);
     }
-    
+
     // TODO: test skipping of logs if diff last LSN and log last LSN matches
     // TODO: test skipping of logs between diffs
     // TODO: test only keep last diff

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -11,27 +11,40 @@ namespace AgDatabaseMove.Unit
 
   public class BackupOrder
   {
-    private readonly List<BackupMetadata> _listBackups;
-    private readonly List<BackupMetadata> _listBackupsWithStripes;
 
-    public BackupOrder()
+    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> baseList)
     {
-      _listBackups = ListBackups();
-      _listBackupsWithStripes = ListBackupsWithStripes();
+      var result = new List<BackupMetadata>();
+      baseList.ForEach(b => {
+        result.Add((BackupMetadata)b.Clone());
+      });
+      result.Reverse();
+      return result;
     }
 
-    private static List<BackupMetadata> ListBackups()
+    private static List<BackupMetadata> GetBackupList()
     {
       return new List<BackupMetadata> {
         new BackupMetadata {
           BackupType = BackupFileTools.BackupType.Log,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955500001,
-          LastLsn = 126000000955800001,
+          FirstLsn = 126000000955200001,
+          LastLsn = 126000000955500001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerA",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
+          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
+        },
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Log,
+          DatabaseBackupLsn = 126000000943800037,
+          CheckpointLsn = 126000000953600034,
+          FirstLsn = 126000000955800001,
+          LastLsn = 126000000965800001,
           DatabaseName = "TestDb",
           ServerName = "ServerB",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
           StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
         },
         new BackupMetadata {
@@ -46,45 +59,6 @@ namespace AgDatabaseMove.Unit
           StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
         },
         new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Diff,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000943800037,
-          LastLsn = 126000000955200001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
-          StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955200001,
-          LastLsn = 126000000955500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
-          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
-        }
-      };
-    }
-
-    private static List<BackupMetadata> ListBackupsWithStripes()
-    {
-      return new List<BackupMetadata> {
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955200001,
-          LastLsn = 126000000955500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\LogBackup_2_stripe_2.trn",
-          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
-        },
-        new BackupMetadata {
           BackupType = BackupFileTools.BackupType.Log,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
@@ -92,100 +66,130 @@ namespace AgDatabaseMove.Unit
           LastLsn = 126000000955800001,
           DatabaseName = "TestDb",
           ServerName = "ServerB",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\LogBackup_1_noStripes.trn",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
           StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
         },
         new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Full,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000943800037,
-          FirstLsn = 126000000936100001,
-          LastLsn = 126000000945500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\FullBackup_stripe_1.full",
-          StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
-        },
-        new BackupMetadata {
           BackupType = BackupFileTools.BackupType.Diff,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000943800037,
+          FirstLsn = 126000000943800038,
           LastLsn = 126000000955200001,
           DatabaseName = "TestDb",
           ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\DiffBackup_stripe_1.diff",
-          StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955200001,
-          LastLsn = 126000000955500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\LogBackup_2_stripe_1.trn",
-          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Full,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000943800037,
-          FirstLsn = 126000000936100001,
-          LastLsn = 126000000945500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\FullBackup_stripe_2.full",
-          StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Diff,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000943800037,
-          LastLsn = 126000000955200001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\DiffBackup_stripe_2.diff",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
           StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
         }
       };
     }
 
-    [Fact]
-    public void BackupChainOrdered()
+    private static List<BackupMetadata> GetBackupListWithoutLogs()
     {
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(_listBackups);
-      var backupChain = new BackupChain(agDatabase.Object);
-
-      var expected = _listBackups.OrderBy(bu => bu.FirstLsn);
-
-      Assert.Equal<IEnumerable>(backupChain.OrderedBackups, expected);
+      var list = GetBackupList();
+      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
+      return list;
+    }
+    
+    private static List<BackupMetadata> GetBackupListWithoutDiff()
+    {
+      var list = GetBackupList();
+      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
+      return list;
     }
 
-    [Fact]
-    public void MissingLink()
+    private static List<BackupMetadata> GetBackupListWithStripes()
     {
-      var backups = ListBackups().Where(b => b.FirstLsn != 126000000955200001).ToList();
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
-
-      var chain = new BackupChain(agDatabase.Object).OrderedBackups;
-      Assert.NotEqual(chain.Last().LastLsn, ListBackups().Max(b => b.LastLsn));
+      var list = GetBackupList();
+      var listWithStripes = CloneBackupMetaDataList(list).ToList();
+      listWithStripes.ForEach(b => {
+        var path = b.PhysicalDeviceName.Split('.');
+        b.PhysicalDeviceName = $"{path[0]}_striped.{path[1]}";
+      });
+      list.AddRange(listWithStripes);
+      return list;
     }
 
-    [Fact]
-    public void BackupChainWithStripesOrdered()
+    private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
+    {
+      var listWithStripes = GetBackupListWithStripes();
+      var duplicate = CloneBackupMetaDataList(listWithStripes);
+      listWithStripes.AddRange(duplicate);
+      return listWithStripes;
+    }
+
+
+
+    private static void VerifyListIsAValidBackupChain(IEnumerable<BackupMetadata> backupChain)
+    {
+      var backupChainList = backupChain.ToList();
+
+      var listOfFileNames = backupChainList.Select(b => b.PhysicalDeviceName).ToList();
+      Assert.True(listOfFileNames.Count == listOfFileNames.Distinct().Count());
+
+      var orderedBackups = CloneBackupMetaDataList(backupChainList)
+        .OrderBy(b => b.LastLsn)
+        // 'PhysicalDeviceName' ordering doesn't matter but need it here to simplify this check for LSN ordering
+        .ThenBy(b => b.PhysicalDeviceName).ToList();
+      Assert.True(backupChainList.SequenceEqual(orderedBackups, new BackupMetadataEqualityComparer()));
+
+      // first one has to be full
+      var full = backupChainList.FirstOrDefault();
+      Assert.NotNull(full);
+      Assert.True(full.BackupType == BackupFileTools.BackupType.Full);
+
+      // removing all the striped files of the full backup
+      backupChainList.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full &&
+                                     b.CheckpointLsn == full.CheckpointLsn);
+
+      var otherFullBackups = backupChainList.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
+      Assert.Equal(0, otherFullBackups);
+
+      // next one can be diff or log
+      var currentBackup = backupChainList.FirstOrDefault();
+      if(currentBackup == null) {
+        return;
+      }
+
+      Assert.True(currentBackup.DatabaseBackupLsn == full.CheckpointLsn);
+
+      if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
+
+        // removing all the striped files of the diff backup
+        backupChainList.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff &&
+                                       b.FirstLsn == currentBackup.FirstLsn && b.LastLsn == currentBackup.LastLsn);
+
+        var otherDiffBackups = backupChainList.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
+        Assert.Equal(0, otherDiffBackups);
+      }
+
+      var prevBackup = currentBackup;
+      backupChainList.ForEach(b => {
+        Assert.True(b.BackupType == BackupFileTools.BackupType.Log &&
+                    (
+                      (prevBackup.FirstLsn == b.FirstLsn && prevBackup.LastLsn == b.LastLsn) ||
+                      prevBackup.LastLsn == b.FirstLsn)
+                    );
+        prevBackup = b;
+      });
+
+    }
+
+    public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
+      new object[] { GetBackupList() },
+      new object[] { GetBackupListWithStripes() },
+      new object[] { GetBackupListWithStripesAndDuplicates() },
+      new object[] { GetBackupListWithoutDiff() },
+      new object[] { GetBackupListWithoutLogs() }
+    };
+    
+    [Theory]
+    [MemberData(nameof(PositiveTestData))]
+    public void BackupChainIsCorrect(List<BackupMetadata> backupList)
     {
       var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(_listBackupsWithStripes);
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
       var backupChain = new BackupChain(agDatabase.Object);
-
-      var expected = _listBackupsWithStripes.OrderBy(bu => bu.FirstLsn);
-
-      Assert.Equal<IEnumerable>(backupChain.OrderedBackups, expected);
+      VerifyListIsAValidBackupChain(backupChain.OrderedBackups);
     }
     
     // TODO: test skipping of logs if diff last LSN and log last LSN matches

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -214,6 +214,18 @@ namespace AgDatabaseMove.Unit
       Assert.Throws<BackupChainException>(() => new BackupChain(agDatabase.Object));
     }
 
+    [Fact]
+    public void MissingLink()
+    {
+      var backups = GetBackupList().Where(b => b.FirstLsn != 126000000955200001).ToList();
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+
+      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+      Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
+      VerifyListIsAValidBackupChain(chain);
+    }
+
     // TODO: test skipping of logs if diff last LSN and log last LSN matches
     // TODO: test skipping of logs between diffs
     // TODO: test only keep last diff

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -160,7 +160,6 @@ namespace AgDatabaseMove.Unit
     public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
       new object[] { GetBackupList() },
       new object[] { GetBackupListWithStripes() },
-      new object[] { GetBackupListWithStripesAndDuplicates() },
       new object[] { GetBackupListWithoutDiff() },
       new object[] { GetBackupListWithoutLogs() }
     };
@@ -200,6 +199,16 @@ namespace AgDatabaseMove.Unit
       var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
       Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
       VerifyListIsAValidBackupChain(chain);
+    }
+
+    [Fact]
+    public void DuplicateFiles()
+    {
+      var backups = GetBackupListWithStripesAndDuplicates();
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+      Assert.Equal(chain.Count, backups.Count/2);
     }
 
     // TODO: test skipping of logs if diff last LSN and log last LSN matches

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -142,7 +142,7 @@ namespace AgDatabaseMove.Unit
         }
         else if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
           Assert.True(foundFull && !foundDiff && !foundLog);
-          Assert.Equal(currentBackup.DatabaseBackupLsn, full.CheckpointLsn);
+          Assert.Equal(full.CheckpointLsn, currentBackup.DatabaseBackupLsn);
           Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
           foundDiff = true;
         }
@@ -208,7 +208,7 @@ namespace AgDatabaseMove.Unit
       var agDatabase = new Mock<IAgDatabase>();
       agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
       var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-      Assert.Equal(chain.Count, backups.Count/2);
+      Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
     }
 
     // TODO: test skipping of logs if diff last LSN and log last LSN matches


### PR DESCRIPTION
Sometimes backups are split into multiple files (called `striped` backup), we need all of them for the restore process.
ref: https://www.sqlservercentral.com/articles/getting-a-list-of-the-striped-backup-files