### PR TITLE
fix(IsValidFilePath): Can now validate Windows UNC paths on Unix runtime

### DIFF
--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -99,7 +99,7 @@ namespace AgDatabaseMove
     private static bool IsValidFilePath(BackupMetadata meta)
     {
       var path = meta.PhysicalDeviceName;
-      return BackupFileTools.IsUrl(path) || BackupFileTools.IsValidPath(path);
+      return BackupFileTools.IsValidFileUrl(path) || BackupFileTools.IsValidFilePath(path);
     }
   }
 }

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -98,7 +98,8 @@ namespace AgDatabaseMove
 
     private static bool IsValidFilePath(BackupMetadata meta)
     {
-      return BackupFileTools.IsUrl(meta.PhysicalDeviceName) || BackupFileTools.IsValidPath(meta.PhysicalDeviceName);
+      var path = meta.PhysicalDeviceName;
+      return BackupFileTools.IsUrl(path) || BackupFileTools.IsUnc(path) || BackupFileTools.IsValidPath(path);
     }
   }
 }

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -99,7 +99,7 @@ namespace AgDatabaseMove
     private static bool IsValidFilePath(BackupMetadata meta)
     {
       var path = meta.PhysicalDeviceName;
-      return BackupFileTools.IsUrl(path) || BackupFileTools.IsUnc(path) || BackupFileTools.IsValidPath(path);
+      return BackupFileTools.IsUrl(path) || BackupFileTools.IsValidPath(path);
     }
   }
 }

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -98,22 +98,7 @@ namespace AgDatabaseMove
 
     private static bool IsValidFilePath(BackupMetadata meta)
     {
-      if(BackupFileTools.IsUrl(meta.PhysicalDeviceName))
-        return true;
-
-      // A quick check before leaning on exceptions
-      if(Path.GetInvalidPathChars().Any(meta.PhysicalDeviceName.Contains))
-        return false;
-
-      try {
-        // This will throw an argument exception if the path is invalid
-        Path.GetFullPath(meta.PhysicalDeviceName);
-        // A relative path won't help us much if the destination is another server. It needs to be rooted.
-        return Path.IsPathRooted(meta.PhysicalDeviceName);
-      }
-      catch(Exception) {
-        return false;
-      }
+      return BackupFileTools.IsUrl(meta.PhysicalDeviceName) || BackupFileTools.IsValidPath(meta.PhysicalDeviceName);
     }
   }
 }

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -15,11 +15,11 @@
       Log // trn  / L
     }
 
-    public static bool IsUrl(string path)
+    public static bool IsValidFileUrl(string path)
     {
       return Uri.TryCreate(path, UriKind.Absolute, out var uriResult)
              && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps || uriResult.IsUnc)
-             && !(path.EndsWith(@"/") || path.EndsWith(@"\"));
+             && Path.HasExtension(path);
     }
 
     public static string BackupTypeToExtension(BackupType type)
@@ -50,7 +50,7 @@
       }
     }
 
-    public static bool IsValidPath(string path)
+    public static bool IsValidFilePath(string path)
     {
       // A quick check before leaning on exceptions
       if(Path.GetInvalidPathChars().Any(path.Contains)) {
@@ -61,7 +61,7 @@
         // This will throw an argument exception if the path is invalid
         Path.GetFullPath(path);
         // A relative path won't help us much if the destination is another server. It needs to be rooted.
-        return Path.IsPathRooted(path);
+        return Path.IsPathRooted(path) && Path.HasExtension(path);
       }
       catch(Exception) {
         return false;

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -1,6 +1,8 @@
 ﻿namespace AgDatabaseMove.SmoFacade
 {
   using System;
+  using System.IO;
+  using System.Linq;
   using System.Text.RegularExpressions;
 
 
@@ -45,5 +47,23 @@
           throw new ArgumentException("Invalid backup type");
       }
     }
+
+    public static bool IsValidPath(string path)
+    {
+      // A quick check before leaning on exceptions
+      if(Path.GetInvalidPathChars().Any(path.Contains))
+        return false;
+
+      try {
+        // This will throw an argument exception if the path is invalid
+        Path.GetFullPath(path);
+        // A relative path won't help us much if the destination is another server. It needs to be rooted.
+        return Path.IsPathRooted(path) || path.StartsWith(@"\\");
+      }
+      catch(Exception) {
+        return false;
+      }
+    }
+
   }
 }

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -51,8 +51,7 @@
     public static bool IsValidPath(string path)
     {
       // A quick check before leaning on exceptions
-      if (Path.GetInvalidPathChars().Any(path.Contains))
-      {
+      if(Path.GetInvalidPathChars().Any(path.Contains)) {
         return false;
       }
 

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -17,7 +17,9 @@
 
     public static bool IsUrl(string path)
     {
-      return Regex.IsMatch(path, @"(http(|s):\/)(\/[^\s]+)+\.([a-zA-Z]+)$");
+      return Uri.TryCreate(path, UriKind.Absolute, out var uriResult)
+             && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps || uriResult.IsUnc)
+             && !(path.EndsWith(@"/") || path.EndsWith(@"\"));
     }
 
     public static string BackupTypeToExtension(BackupType type)
@@ -62,17 +64,6 @@
         return Path.IsPathRooted(path);
       }
       catch(Exception) {
-        return false;
-      }
-    }
-
-    public static bool IsUnc(string path)
-    {
-      try {
-        var uri = new Uri(path);
-        return uri.IsUnc;
-      }
-      catch {
         return false;
       }
     }

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -51,19 +51,31 @@
     public static bool IsValidPath(string path)
     {
       // A quick check before leaning on exceptions
-      if(Path.GetInvalidPathChars().Any(path.Contains))
+      if (Path.GetInvalidPathChars().Any(path.Contains))
+      {
         return false;
+      }
 
-      try {
+      try { 
         // This will throw an argument exception if the path is invalid
         Path.GetFullPath(path);
         // A relative path won't help us much if the destination is another server. It needs to be rooted.
-        return Path.IsPathRooted(path) || path.StartsWith(@"\\");
+        return Path.IsPathRooted(path);
       }
       catch(Exception) {
         return false;
       }
     }
 
+    public static bool IsUnc(string path)
+    {
+      try {
+        var uri = new Uri(path);
+        return uri.IsUnc;
+      }
+      catch {
+        return false;
+      }
+    }
   }
 }

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -132,7 +132,7 @@ namespace AgDatabaseMove.SmoFacade
       var restore = new Restore { Database = databaseName, NoRecovery = true };
 
       foreach(var backup in backupOrder) {
-        var device = BackupFileTools.IsUrl(backup.PhysicalDeviceName) ? DeviceType.Url : DeviceType.File;
+        var device = BackupFileTools.IsValidFileUrl(backup.PhysicalDeviceName) ? DeviceType.Url : DeviceType.File;
         var backupDeviceItem = new BackupDeviceItem(backup.PhysicalDeviceName, device);
         if(_credentialName != null && device == DeviceType.Url)
           backupDeviceItem.CredentialName = _credentialName;
@@ -207,7 +207,7 @@ namespace AgDatabaseMove.SmoFacade
       var backupDirectory = BackupDirectoryOrDefault(backupDirectoryPathQuery);
       var filePath =
         $"{backupDirectory}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
-      var deviceType = BackupFileTools.IsUrl(filePath) ? DeviceType.Url : DeviceType.File;
+      var deviceType = BackupFileTools.IsValidFileUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);
       if(_credentialName != null && deviceType == DeviceType.Url)

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -17,25 +17,29 @@ namespace AgDatabaseMove.Unit
     [InlineData(@"https://storage-account.blob.core.windows.net/container/file.bad")]
     [InlineData(@"https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn")]
     [InlineData(@"http://a.bak")]
-    [InlineData(@"\\UNC\syntax\path\file")]
-    [InlineData(@"\\server\path\file.ext")]
-    [InlineData(@"\\server\file")]
+    [InlineData(@"\\UNC\syntax\path\file.ext")]
     [InlineData(@"\\server\file.ext")]
     [InlineData(@"//Unix/syntax/file.ext")]
     public void ValidUrlTests(string url)
     {
-      Assert.True(BackupFileTools.IsUrl(url));
+      Assert.True(BackupFileTools.IsValidFileUrl(url));
     }
 
     [Theory]
+    [InlineData(@"")]
+    [InlineData(@" ")]
+    [InlineData(@"c:\hello\a.bak")]
     [InlineData(@"\\C:/")]
     [InlineData(@"\wrongUNC\file.txt")]
     [InlineData(@"/wrongUNC/file.txt")]
-    [InlineData(@"https://storage-account.blob.core.windows.net/dir/")]
+    [InlineData(@"\\server\dir")]
+    [InlineData(@"\\server\dir\")]
+    [InlineData(@"https://storage-account.blob.core.windows.net/dir")]
+    [InlineData(@"http://storage-account.blob.core.windows.net/dir")]
     [InlineData(@"http://storage-account.blob.core.windows.net/dir/")]
     public void InvalidUrlTests(string url)
     {
-      Assert.False(BackupFileTools.IsUrl(url));
+      Assert.False(BackupFileTools.IsValidFileUrl(url));
     }
 
     [Theory]
@@ -58,28 +62,29 @@ namespace AgDatabaseMove.Unit
 
     [Theory]
     [InlineData(@"C:\dir\file.ext")]
-    [InlineData(@"C:\dir\")]
-    [InlineData(@"C:\dir")]
-    [InlineData(@"C:\")]
-    [InlineData(@"/some/file")]
-    [InlineData(@"/dir")]
-    [InlineData(@"/")]
+    [InlineData(@"/some/file.ext")]
+    
     public void ValidPathTests(string path)
     {
-      Assert.True(BackupFileTools.IsValidPath(path));
+      Assert.True(BackupFileTools.IsValidFilePath(path));
     }
 
     [Theory]
     [InlineData(@"")]
     [InlineData(@" ")]
+    [InlineData(@"/dir")]
+    [InlineData(@"/")]
     [InlineData(@"file.ext")]
     [InlineData(@"dir\file.ext")]
     [InlineData(@"C dir\file.ext")]
     [InlineData(@"dir")]
+    [InlineData(@"C:\dir\")]
+    [InlineData(@"C:\dir")]
+    [InlineData(@"C:\")]
     [InlineData(@"C:\inval|d")]
     public void InValidPathTests(string path)
     {
-      Assert.False(BackupFileTools.IsValidPath(path));
+      Assert.False(BackupFileTools.IsValidFilePath(path));
     }
   }
 }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -64,8 +64,6 @@ namespace AgDatabaseMove.Unit
     [InlineData(@"C:\dir\")]
     [InlineData(@"C:\dir")]
     [InlineData(@"C:\")]
-    [InlineData(@"\\unc\share\dir\file.ext")]
-    [InlineData(@"\\unc\share")]
     [InlineData(@"/some/file")]
     [InlineData(@"/dir")]
     [InlineData(@"/")]
@@ -85,6 +83,25 @@ namespace AgDatabaseMove.Unit
     public void InValidPathTests(string path)
     {
       Assert.False(BackupFileTools.IsValidPath(path));
+    }
+
+    [Theory]
+    [InlineData(@"\\server\file")]
+    [InlineData(@"\\server\path\file")]
+    [InlineData(@"\\server\path\file.ext")]
+    [InlineData(@"//Unix/syntax/file.ext")]
+    public void ValidUncTests(string path)
+    {
+      Assert.True(BackupFileTools.IsUnc(path));
+    }
+
+    [Theory]
+    [InlineData(@"\\C:/")]
+    [InlineData(@"\server\")]
+    [InlineData(@"/server/")]
+    public void InvalidUncTests(string path)
+    {
+      Assert.False(BackupFileTools.IsUnc(path));
     }
   }
 }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -7,38 +7,37 @@ namespace AgDatabaseMove.Unit
 
   public class BackupFileToolsTest
   {
-    public static IEnumerable<object[]> UrlFileExamples => new List<object[]> {
-      new object[] { "https://hello/a.bak" },
-      new object[] { "https://hello/a.full" },
-      new object[] { "https://storage-account.blob.core.windows.net/container/file.trn" },
-      new object[] { "https://hello/a.diff" },
-      new object[] { "https://a.diff" },
-      new object[] { "https://1/2/3/4/5/a.diff" },
-      new object[] { "https://storage-account.blob.core.windows.net/container/file.bad" },
-      new object[]
-        { "https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn" },
-      new object[] { "http://hello/a.bak" }
-    };
-
-    public static IEnumerable<object[]> NonUrlFileExamples => new List<object[]> {
-      new object[] { @"c:\hello\a.bak" },
-      new object[] { @"\\abc\hello/a.bak" },
-      new object[] { "https://storage-account.blob.core.windows.net/container" },
-      new object[] { "http://storage-account.blob.core.windows.net/container" }
-    };
 
     [Theory]
-    [MemberData(nameof(UrlFileExamples))]
-    public void UrlFilesAreUrl(string file)
+    [InlineData(@"https://hello/a.bak")]
+    [InlineData(@"https://hello/a.full")]
+    [InlineData(@"https://storage-account.blob.core.windows.net/container/file.trn")]
+    [InlineData(@"https://hello/a.diff")]
+    [InlineData(@"https://1/2/3/4/5/a.diff")]
+    [InlineData(@"https://storage-account.blob.core.windows.net/container/file.bad")]
+    [InlineData(@"https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn")]
+    [InlineData(@"http://a.bak")]
+    // works for UNC urls too
+    [InlineData(@"\\server\file")]
+    [InlineData(@"\\server\path\file")]
+    [InlineData(@"\\server\path\file.ext")]
+    [InlineData(@"//Unix/syntax/file.ext")]
+    public void ValidUrlTests(string url)
     {
-      Assert.True(BackupFileTools.IsUrl(file));
+      Assert.True(BackupFileTools.IsUrl(url));
     }
 
     [Theory]
-    [MemberData(nameof(NonUrlFileExamples))]
-    public void NonUrlFilesAreNotUrl(string file)
+    // can't be to a dir
+    [InlineData(@"https://storage-account.blob.core.windows.net/container/")]
+    [InlineData(@"http://storage-account.blob.core.windows.net/container/")]
+    [InlineData(@"C:/hello/a.bak")]
+    [InlineData(@"\\C:/")]
+    [InlineData(@"\server\file.txt")]
+    [InlineData(@"/server/file.txt")]
+    public void InvalidUrlTests(string url)
     {
-      Assert.False(BackupFileTools.IsUrl(file));
+      Assert.False(BackupFileTools.IsUrl(url));
     }
 
     [Theory]
@@ -83,25 +82,6 @@ namespace AgDatabaseMove.Unit
     public void InValidPathTests(string path)
     {
       Assert.False(BackupFileTools.IsValidPath(path));
-    }
-
-    [Theory]
-    [InlineData(@"\\server\file")]
-    [InlineData(@"\\server\path\file")]
-    [InlineData(@"\\server\path\file.ext")]
-    [InlineData(@"//Unix/syntax/file.ext")]
-    public void ValidUncTests(string path)
-    {
-      Assert.True(BackupFileTools.IsUnc(path));
-    }
-
-    [Theory]
-    [InlineData(@"\\C:/")]
-    [InlineData(@"\server\")]
-    [InlineData(@"/server/")]
-    public void InvalidUncTests(string path)
-    {
-      Assert.False(BackupFileTools.IsUnc(path));
     }
   }
 }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -58,5 +58,33 @@ namespace AgDatabaseMove.Unit
     {
       Assert.Equal(type, BackupFileTools.BackupTypeAbbrevToType(abbrev));
     }
+
+    [Theory]
+    [InlineData(@"C:\dir\file.ext")]
+    [InlineData(@"C:\dir\")]
+    [InlineData(@"C:\dir")]
+    [InlineData(@"C:\")]
+    [InlineData(@"\\unc\share\dir\file.ext")]
+    [InlineData(@"\\unc\share")]
+    [InlineData(@"/some/file")]
+    [InlineData(@"/dir")]
+    [InlineData(@"/")]
+    public void ValidPathTests(string path)
+    {
+      Assert.True(BackupFileTools.IsValidPath(path));
+    }
+
+    [Theory]
+    [InlineData(@"")]
+    [InlineData(@" ")]
+    [InlineData(@"file.ext")]
+    [InlineData(@"dir\file.ext")]
+    [InlineData(@"C dir\file.ext")]
+    [InlineData(@"dir")]
+    [InlineData(@"C:\inval|d")]
+    public void InValidPathTests(string path)
+    {
+      Assert.False(BackupFileTools.IsValidPath(path));
+    }
   }
 }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -17,10 +17,10 @@ namespace AgDatabaseMove.Unit
     [InlineData(@"https://storage-account.blob.core.windows.net/container/file.bad")]
     [InlineData(@"https://storage-account.blob.core.windows.net/container/sql/db_name/backup_2020_09_02_170003_697.trn")]
     [InlineData(@"http://a.bak")]
-    // works for UNC urls too
-    [InlineData(@"\\server\file")]
-    [InlineData(@"\\server\path\file")]
+    [InlineData(@"\\UNC\syntax\path\file")]
     [InlineData(@"\\server\path\file.ext")]
+    [InlineData(@"\\server\file")]
+    [InlineData(@"\\server\file.ext")]
     [InlineData(@"//Unix/syntax/file.ext")]
     public void ValidUrlTests(string url)
     {
@@ -28,13 +28,11 @@ namespace AgDatabaseMove.Unit
     }
 
     [Theory]
-    // can't be to a dir
-    [InlineData(@"https://storage-account.blob.core.windows.net/container/")]
-    [InlineData(@"http://storage-account.blob.core.windows.net/container/")]
-    [InlineData(@"C:/hello/a.bak")]
     [InlineData(@"\\C:/")]
-    [InlineData(@"\server\file.txt")]
-    [InlineData(@"/server/file.txt")]
+    [InlineData(@"\wrongUNC\file.txt")]
+    [InlineData(@"/wrongUNC/file.txt")]
+    [InlineData(@"https://storage-account.blob.core.windows.net/dir/")]
+    [InlineData(@"http://storage-account.blob.core.windows.net/dir/")]
     public void InvalidUrlTests(string url)
     {
       Assert.False(BackupFileTools.IsUrl(url));


### PR DESCRIPTION
Before, `Path.IsPathRooted(meta.PhysicalDeviceName);` would return false for Windows UNC paths on Unix runtime due to a difference in dotnet's implementation of the function for the diff runtimes:

Windows Runtime: https://github.com/dotnet/runtime/blob/44f8f0faee42367bdd39277d8295f6e914ad7f4a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs#L194 
vs.
Unix Runtime: https://github.com/dotnet/runtime/blob/44f8f0faee42367bdd39277d8295f6e914ad7f4a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs#L113

This would lead to backup files being filtered out and an exception being thrown during the creation of the backup chain.

Now we use the `IsUnc` property of the `Uri` class to detect UNC paths and since UNCs have to be fully-qualified by design, we can validate them straight away (just like how we do for URLs).

Have also made a few refactors to ease testing of this new approach.