### PR TITLE
fix(rollback): servername filter on query

### DIFF
--- a/src/SmoFacade/Database.cs
+++ b/src/SmoFacade/Database.cs
@@ -80,11 +80,9 @@ namespace AgDatabaseMove.SmoFacade
                     "WHERE [type] = 'D' " +
                     "AND database_name = @dbName " +
                     "AND is_copy_only = 0" +
-                    "AND server_name = @@SERVERNAME " +
                   ") " +
                   "AND s.database_name = @dbName " +
                   "AND is_copy_only = 0 " +
-                  "AND s.server_name = @@SERVERNAME " +
                   "ORDER BY s.backup_start_date DESC, backup_finish_date";
 
       using var cmd = _server.SqlConnection.CreateCommand();


### PR DESCRIPTION
if you use `@@servername` in the filter, then the backupChain is not retrieved correctly for databases restored from another server

