### PR TITLE
fix(ci): azure pipeline vm image

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 jobs:
   - job: Build
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     strategy:
       matrix:
         Release:
@@ -62,7 +62,7 @@ jobs:
 
   - job: CodeCleanup
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: 'windows-latest'
     steps:
     - task: NuGetToolInstaller@0
     - powershell: |


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml

##[warning]The windows-2016 environment is deprecated and will be removed on March 15, 2022. Migrate to windows-latest instead. For more details, see https://github.com/actions/virtual-environments/issues/4312

Closes #84