### PR TITLE
feat(polly): retry db drop wait longer

### DIFF
--- a/src/SmoFacade/Database.cs
+++ b/src/SmoFacade/Database.cs
@@ -134,10 +134,9 @@ namespace AgDatabaseMove.SmoFacade
       // Deleting the database while it is initializing will leave it in a state where system redo threads are stuck.
       // This leaves the database in a state that a SQL Server service restart prior to deletion.
 
-
       var policyPrep = Policy
         .Handle<Exception>()
-        .WaitAndRetry(3, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(10, retryAttempt)));
+        .WaitAndRetry(6, retryAttempt => TimeSpan.FromMilliseconds(Math.Pow(5, retryAttempt)));
 
       // ensure database is not in AvailabilityGroup, WaitAndRetry loop for each instance to sync
       policyPrep.Execute(() => {


### PR DESCRIPTION
4 retries starting at 10ms:
10ms, 100ms, 1000ms (1 second) 

6 retries starting at 5ms:
5ms, 25ms, 125ms, 625ms, 3125ms (3.1 seconds), 15625ms (15.625 seconds)