### PR TITLE
feat(login): create new sql login

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -12,9 +12,13 @@ namespace AgDatabaseMove
   using System.Data.SqlClient;
   using System.Linq;
   using System.Threading;
+  using System.Threading.Tasks;
   using Exceptions;
+  using Microsoft.SqlServer.Management.Smo;
   using Polly;
   using SmoFacade;
+  using AvailabilityGroup = SmoFacade.AvailabilityGroup;
+  using Server = SmoFacade.Server;
 
 
   public interface IAgDatabase
@@ -158,7 +162,19 @@ namespace AgDatabaseMove
 
     public void AddLogin(LoginProperties login)
     {
-      _listener.ForEachAgInstance(server => server.AddLogin(login));
+      if (login.LoginType == LoginType.SqlLogin && login.Sid == null) {
+        AddNewSqlLogin(login);
+      } 
+      else {
+        _listener.ForEachAgInstance(server => server.AddLogin(login));
+      }
+    }
+
+    private void AddNewSqlLogin(LoginProperties login)
+    {
+      var createdLogin = _listener.Primary.AddLogin(login);
+      login.Sid = createdLogin.Sid;
+      Parallel.ForEach(_listener.Secondaries, server => server.AddLogin(login));
     }
 
     public IEnumerable<RoleProperties> AssociatedRoles()

--- a/src/SmoFacade/Login.cs
+++ b/src/SmoFacade/Login.cs
@@ -123,6 +123,7 @@ namespace AgDatabaseMove.SmoFacade
       else {
         login.Create();
       }
+      login.Refresh();
 
       return login;
     }

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -278,11 +278,11 @@ namespace AgDatabaseMove.SmoFacade
       backup.SqlBackup(_server);
     }
 
-    public void AddLogin(LoginProperties login)
+    public Login AddLogin(LoginProperties login)
     {
       var matchingLogin =
         Logins.SingleOrDefault(l => l.Name.Equals(login.Name, StringComparison.InvariantCultureIgnoreCase));
-      if(matchingLogin == null) matchingLogin = new Login(login, this);
+      return matchingLogin ?? new Login(login, this);
     }
 
     public void AddRole(LoginProperties login, RoleProperties role)

--- a/tests/AgDatabaseMove.Integration/Config/TestAgDatabaseConfig.cs
+++ b/tests/AgDatabaseMove.Integration/Config/TestAgDatabaseConfig.cs
@@ -1,0 +1,10 @@
+﻿namespace AgDatabaseMove.Integration.Config
+{
+  public class TestAgDatabaseConfig
+  {
+    public string ConnectionString { get; set; }
+    public string DatabaseName { get; set; }
+    public string BackUpPathSqlQuery { get; set; }
+    public string CredentialName { get; set; }
+  }
+}

--- a/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
+++ b/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
@@ -1,0 +1,48 @@
+﻿using AgDatabaseMove.Integration.Config;
+using System;
+
+namespace AgDatabaseMove.Integration.Fixtures
+{
+  public class TestAgDatabaseFixture : TestConfiguration<TestAgDatabaseConfig>, IDisposable
+  {
+    public TestConfiguration<TestLoginConfig> _login;
+
+    public AgDatabase _agDatabase;
+
+    public TestAgDatabaseFixture() : base("TestAgDatabase")
+    {
+      _agDatabase = ConstructAgDatabase();
+      _login = new TestConfiguration<TestLoginConfig>("TestLogin");
+    }
+
+    // Public fields for testing new sql login creation.
+    public string _loginPassword => _login._config.Password;
+
+    public string _loginName => _login._config.LoginName;
+
+    public string _loginDefaultDatabase => _login._config.DefaultDatabase;
+
+    public AgDatabase ConstructAgDatabase()
+    {
+      var dbConfig = new DatabaseConfig
+      {
+        BackupPathSqlQuery = _config.BackUpPathSqlQuery,
+        ConnectionString = _config.ConnectionString,
+        DatabaseName = _config.DatabaseName,
+        CredentialName = _config.CredentialName
+      };
+
+      return new AgDatabase(dbConfig);
+    }
+    public void Dispose()
+    {
+      // Cleanup new Sql logins created.
+      _agDatabase._listener.Primary._server.Logins[_loginName]?.DropIfExists();
+      foreach(var server in _agDatabase._listener.Secondaries) {
+        server._server.Logins[_loginName]?.DropIfExists();
+      }
+
+      _agDatabase.Dispose();
+    }
+  }
+}

--- a/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
+++ b/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
@@ -55,8 +55,8 @@
 
     public void Dispose()
     {
-      _agDatabase.DropLogin(new LoginProperties { Name = _loginConfig.LoginName });
-      _agDatabase.Dispose();
+      _agDatabase?.DropLogin(new LoginProperties { Name = _loginConfig.LoginName });
+      _agDatabase?.Dispose();
     }
   }
 }

--- a/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
+++ b/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
@@ -17,14 +17,13 @@
     public void TestLoginsExist()
     {
       _fixture._agDatabase.ContainsLogin(_fixture._loginConfig.LoginName);
-      Assert.True(true);
     }
 
     [Fact]
     public void TestLoginSidsMatch()
     {
-      Assert.Equal(_fixture._createdLogins.Select(l => l.Sid), 
-                   Enumerable.Repeat(_fixture._createdLogins.First().Sid, _fixture._createdLogins.Count()));
+      var sid = _fixture._createdLogins.First().Sid;
+      Assert.All(_fixture._createdLogins.Select(l => l.Sid), s => Assert.Equal(s, sid));
     }
   }
 }

--- a/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
+++ b/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
@@ -1,0 +1,75 @@
+﻿using AgDatabaseMove.Integration.Fixtures;
+using AgDatabaseMove.SmoFacade;
+using System.Collections.Generic;
+using Xunit;
+using Smo = Microsoft.SqlServer.Management.Smo;
+
+namespace AgDatabaseMove.Integration
+{
+  public class TestAgDatabase : IClassFixture<TestAgDatabaseFixture>
+  {
+    private readonly TestAgDatabaseFixture _testAgDatabaseFixture;
+
+    public TestAgDatabase(TestAgDatabaseFixture testAgDatabaseFixture)
+    {
+      _testAgDatabaseFixture = testAgDatabaseFixture;
+    }
+
+    private AgDatabase AgDatabase => _testAgDatabaseFixture._agDatabase;
+
+    private string LoginName => _testAgDatabaseFixture._loginName;
+
+    private string LoginPassword => _testAgDatabaseFixture._loginPassword;
+
+    private string DefaultDatabase => _testAgDatabaseFixture._loginDefaultDatabase;
+
+    private void CreateNewSqlLogin(LoginProperties login)
+    {
+      AgDatabase.AddLogin(login);
+    }
+
+    private void TestLoginExistsOnAg(List<Smo.Login> createdLogins)
+    {
+      createdLogins.ForEach(Assert.NotNull);
+    }
+
+    private List<Smo.Login> GetCreatedLogins()
+    {
+      List<Smo.Login> logins = new List<Smo.Login>();
+      logins.Add(AgDatabase._listener.Primary._server.Logins[LoginName]);
+      foreach(var server in AgDatabase._listener.Secondaries)
+      {
+        logins.Add(server._server.Logins[LoginName]);
+      }
+
+      // Verifying login was created on more than primary.
+      Assert.True(logins.Count > 1);
+      return logins;
+    }
+
+    private void TestLoginSidsMatch(List<Smo.Login> createdLogins)
+    {
+      for (int i = 0; i < createdLogins.Count - 1; i++)
+      {
+        Assert.Equal(createdLogins[i].Sid, createdLogins[i + 1].Sid);
+      }
+    }
+
+    [Fact]
+    public void CreateNewSqlLoginTest()
+    {
+      var newSqlLogin = new LoginProperties
+      {
+        Name = LoginName,
+        Password = LoginPassword,
+        LoginType = Smo.LoginType.SqlLogin,
+        DefaultDatabase = DefaultDatabase
+      };
+
+      CreateNewSqlLogin(newSqlLogin);
+      var createdLogins = GetCreatedLogins();
+      TestLoginExistsOnAg(createdLogins);
+      TestLoginSidsMatch(createdLogins);
+    }
+  }
+}


### PR DESCRIPTION
Added functionality to create a new Sql login replicated on all replicas of an availability group. Requires creation of login on primary, saving SID, then using the saved SID to create the same login on secondary's.
Currently extends `AddLogin` to detect a case where caller may be trying to create a Sql login which does not yet exist. 

Added integration test for `AgDatabase` to test functionality described above. Tests for existence of logins, logins are created on more than just the primary, and verifies Sid of logins match.

These changes pass the tests included. I also manually verified creation of logins with matching Sid on each replica of availability group.