### PR TITLE
fix(backup-chain): 30-day history

### DIFF
--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -37,7 +37,7 @@ namespace AgDatabaseMove
         orderedBackups.AddRange(nextLogBackups);
         prevBackup = orderedBackups.Last();
       }
-
+       
       _orderedBackups = orderedBackups;
     }
 
@@ -62,7 +62,8 @@ namespace AgDatabaseMove
         .Where(b => b.BackupType == BackupFileTools.BackupType.Full)
         .OrderByDescending(d => d.CheckpointLsn).ToList();
 
-      if(!fullBackupsOrdered.Any()) throw new BackupChainException("Could not find any full backups");
+      if(!fullBackupsOrdered.Any()) 
+        throw new BackupChainException("Could not find any full backups");
 
       var targetCheckpointLsn = fullBackupsOrdered.First().CheckpointLsn;
       // get all the stripes of this backup
@@ -73,11 +74,14 @@ namespace AgDatabaseMove
       BackupMetadata lastFullBackup)
     {
       var diffBackupsOrdered = backups
-        .Where(b => b.BackupType == BackupFileTools.BackupType.Diff &&
-                    b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn)
+        .Where(b => 
+                 b.BackupType == BackupFileTools.BackupType.Diff &&
+                 b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn)
         .OrderByDescending(b => b.LastLsn).ToList();
 
-      if(!diffBackupsOrdered.Any()) return new List<BackupMetadata>();
+      if(!diffBackupsOrdered.Any()) 
+        return new List<BackupMetadata>();
+
       var targetLastLsn = diffBackupsOrdered.First().LastLsn;
       // get all the stripes of this backup
       return diffBackupsOrdered.Where(diffBackup => diffBackup.LastLsn == targetLastLsn);

--- a/src/SmoFacade/Database.cs
+++ b/src/SmoFacade/Database.cs
@@ -77,12 +77,7 @@ namespace AgDatabaseMove.SmoFacade
                   "s.database_backup_lsn, s.checkpoint_lsn, s.[type] AS backup_type, s.server_name, s.recovery_model " +
                   "FROM msdb.dbo.backupset s " +
                   "INNER JOIN msdb.dbo.backupmediafamily m ON s.media_set_id = m.media_set_id " +
-                  "WHERE s.last_lsn >= (" +
-                  "SELECT MAX(last_lsn) FROM msdb.dbo.backupset " +
-                  "WHERE [type] = 'D' " +
-                  "AND database_name = @dbName " +
-                  "AND is_copy_only = 0" +
-                  ") " +
+                  "WHERE s.backup_start_date > DATEADD(day, -30, GETDATE())" +
                   "AND s.database_name = @dbName " +
                   "AND is_copy_only = 0 " +
                   "ORDER BY s.backup_start_date DESC, backup_finish_date";

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -267,7 +267,7 @@ namespace AgDatabaseMove.SmoFacade
     {
       var backupDirectory = BackupDirectoryOrDefault(backupDirectoryPathQuery);
       var filePath =
-        $"{backupDirectory}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
+        $"{backupDirectory}/{_server.Name}/{databaseName}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
       var deviceType = BackupFileTools.IsValidFileUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);


### PR DESCRIPTION
uses `WHERE s.backup_start_date > DATEADD(day, -30, GETDATE())` 30 day window instead of max(last_lsn)

alternative would be like something in https://github.com/factset/AgDatabaseMove/pull/97