### PR TITLE
feat(restore): logical file rename

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -34,6 +34,7 @@ namespace AgDatabaseMove
     void Restore(IEnumerable<BackupMetadata> backupOrder, Func<int, TimeSpan> retryDurationProvider,
       Func<string, string> fileRelocation = null);
 
+    void RenameLogicalFileName(Func<string, string> fileRenamer);
     void AddLogin(LoginProperties login);
     IEnumerable<LoginProperties> AssociatedLogins();
     void DropLogin(LoginProperties login);

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -120,7 +120,7 @@ namespace AgDatabaseMove
 
     public void RenameLogicalFileName(Func<string, string> fileRenamer)
     {
-      _listener.Primary.LogicalFileRename(Name, fileRenamer);
+      _listener.Primary.RenameLogicalFileName(Name, fileRenamer);
     }
 
     /// <summary>

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -118,6 +118,11 @@ namespace AgDatabaseMove
       _listener.ForEachAgInstance(s => s.Restore(backupOrder, Name, retryDurationProvider, fileRelocation));
     }
 
+    public void RenameLogicalFileName(Func<string, string> fileRenamer)
+    {
+      _listener.Primary.LogicalFileRename(Name, fileRenamer);
+    }
+
     /// <summary>
     ///   Builds a list of recent backups from msdb on each AG instance.
     /// </summary>

--- a/src/AgDatabaseMove.cs
+++ b/src/AgDatabaseMove.cs
@@ -80,8 +80,10 @@ namespace AgDatabaseMove
         foreach(var loginProperty in _options.Source.AssociatedLogins().Select(UpdateDefaultDb))
           _options.Destination.AddLogin(loginProperty);
 
-      if(_options.Finalize)
+      if(_options.Finalize) {
         _options.Destination.JoinAg();
+        _options.Destination.RenameLogicalFileName(_options.FileRelocator);
+      }
 
       return backupList.Max(bl => bl.LastLsn);
     }

--- a/src/SmoFacade/Database.cs
+++ b/src/SmoFacade/Database.cs
@@ -12,7 +12,7 @@ namespace AgDatabaseMove.SmoFacade
   /// </summary>
   public class Database
   {
-    private readonly Microsoft.SqlServer.Management.Smo.Database _database;
+    internal readonly Microsoft.SqlServer.Management.Smo.Database _database;
     private readonly Server _server;
 
     internal Database(Microsoft.SqlServer.Management.Smo.Database database, Server server)

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -70,14 +70,14 @@ namespace AgDatabaseMove.SmoFacade
       var secondaryNames = availabilityGroup.Replicas.Where(l => l != primaryName);
 
       // Connect to each server instance
-      Primary = AgInstanceNameToServer(ref connectionStringBuilder, primaryName, credentialName, availabilityGroup.Name);
+      Primary = AgInstanceNameToServer(ref connectionStringBuilder, primaryName, credentialName);
       AvailabilityGroup = Primary.AvailabilityGroups.Single(ag => ag.Name == availabilityGroup.Name);
 
       _secondaries = new List<Server>();
       foreach(var secondaryName in secondaryNames)
         _secondaries.Add(AgInstanceNameToServer(ref connectionStringBuilder,
                                                 secondaryName,
-                                                credentialName, availabilityGroup.Name));
+                                                credentialName));
     }
 
     public IEnumerable<Server> ReplicaInstances => Secondaries.Union(new[] { Primary });
@@ -132,11 +132,11 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     private static Server AgInstanceNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName,
-      string credentialName, string agName)
+      string credentialName)
     {
       try {
         connBuilder.DataSource = ResolveDnsHostNameForInstance(agInstanceName, connBuilder.DataSource);
-        return new Server(connBuilder.ToString(), credentialName, agName);
+        return new Server(connBuilder.ToString(), credentialName);
       }
       catch(Exception e) {
         throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS", e);

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -70,14 +70,14 @@ namespace AgDatabaseMove.SmoFacade
       var secondaryNames = availabilityGroup.Replicas.Where(l => l != primaryName);
 
       // Connect to each server instance
-      Primary = AgInstanceNameToServer(ref connectionStringBuilder, primaryName, credentialName);
+      Primary = AgInstanceNameToServer(ref connectionStringBuilder, primaryName, credentialName, availabilityGroup.Name);
       AvailabilityGroup = Primary.AvailabilityGroups.Single(ag => ag.Name == availabilityGroup.Name);
 
       _secondaries = new List<Server>();
       foreach(var secondaryName in secondaryNames)
         _secondaries.Add(AgInstanceNameToServer(ref connectionStringBuilder,
                                                 secondaryName,
-                                                credentialName));
+                                                credentialName, availabilityGroup.Name));
     }
 
     public IEnumerable<Server> ReplicaInstances => Secondaries.Union(new[] { Primary });
@@ -132,11 +132,11 @@ namespace AgDatabaseMove.SmoFacade
     }
 
     private static Server AgInstanceNameToServer(ref SqlConnectionStringBuilder connBuilder, string agInstanceName,
-      string credentialName)
+      string credentialName, string agName)
     {
       try {
         connBuilder.DataSource = ResolveDnsHostNameForInstance(agInstanceName, connBuilder.DataSource);
-        return new Server(connBuilder.ToString(), credentialName);
+        return new Server(connBuilder.ToString(), credentialName, agName);
       }
       catch(Exception e) {
         throw new ArgumentException($"agInstanceName param {agInstanceName} cannot be resolved by DNS", e);

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -18,15 +18,17 @@ namespace AgDatabaseMove.SmoFacade
   public class Server : IDisposable
   {
     private readonly string _connectionString;
+    private readonly string _agName;
     internal readonly string _credentialName;
     internal readonly Microsoft.SqlServer.Management.Smo.Server _server;
 
-    public Server(string connectionString, string credentialName = null)
+    public Server(string connectionString, string credentialName = null, string agName = "")
     {
       _connectionString = connectionString;
       SqlConnection = new SqlConnection(_connectionString);
       _server = new Microsoft.SqlServer.Management.Smo.Server(new ServerConnection(SqlConnection));
       _credentialName = credentialName;
+      _agName = agName;
     }
 
     public Server(SqlConnectionStringBuilder connectionStringBuilder) :
@@ -42,7 +44,7 @@ namespace AgDatabaseMove.SmoFacade
       .Select(d => new Database(d, this));
 
     private AvailabilityGroup AvailabilityGroup =>
-      AvailabilityGroups.Single(ag => ag.Listeners.Contains(AgName(), StringComparer.InvariantCultureIgnoreCase));
+      AvailabilityGroups.FirstOrDefault(ag => ag.Name.Equals(_agName, StringComparison.InvariantCultureIgnoreCase));
 
     public string Name => _server.Name;
 
@@ -102,18 +104,6 @@ namespace AgDatabaseMove.SmoFacade
       return lastDirIndex > 0
         ? physicalName.Remove(0, lastDirIndex + 1)
         : physicalName;
-    }
-
-    /// <summary>
-    ///   Parses the AG name from the connection's DataSource.
-    /// </summary>
-    /// <returns>The availability group name.</returns>
-    private string AgName()
-    {
-      var dotIndex = SqlConnection?.DataSource?.IndexOf('.');
-      if(!dotIndex.HasValue)
-        return string.Empty;
-      return dotIndex >= 0 ? SqlConnection.DataSource.Remove(dotIndex.Value) : SqlConnection.DataSource;
     }
 
     /// <summary>
@@ -226,7 +216,7 @@ namespace AgDatabaseMove.SmoFacade
         restore.Devices.Remove(backupDeviceItem);
       }
 
-      if (fileRelocation != null)
+      if (fileRelocation != null && AvailabilityGroup.IsPrimaryInstance)
         LogicalFileRename(databaseName, fileRelocation);
     }
 
@@ -236,16 +226,16 @@ namespace AgDatabaseMove.SmoFacade
       if (db.Restoring)
         db.RestoreWithRecovery();
 
-      foreach (FileGroup fileGroup in (SmoCollectionBase)db._database.FileGroups)
+      foreach (FileGroup fileGroup in db._database.FileGroups)
       {
-        DataFile[] dataFiles = new DataFile[fileGroup.Files.Count];
+        var dataFiles = new DataFile[fileGroup.Files.Count];
         fileGroup.Files.CopyTo(dataFiles, 0);
-        foreach (DataFile dataFile in dataFiles)
+        foreach (var dataFile in dataFiles)
           dataFile.Rename(fileRelocation(dataFile.Name));
       }
-      LogFile[] logFiles = new LogFile[db._database.LogFiles.Count];
+      var logFiles = new LogFile[db._database.LogFiles.Count];
       db._database.LogFiles.CopyTo(logFiles, 0);
-      foreach (LogFile logFile in logFiles)
+      foreach (var logFile in logFiles)
         logFile.Rename(fileRelocation(logFile.Name));
     }
 

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -238,14 +238,14 @@ namespace AgDatabaseMove.SmoFacade
 
       foreach (FileGroup fileGroup in (SmoCollectionBase)db._database.FileGroups)
       {
-        DataFile[] array = new DataFile[fileGroup.Files.Count];
-        fileGroup.Files.CopyTo(array, 0);
-        foreach (DataFile dataFile in array)
+        DataFile[] dataFiles = new DataFile[fileGroup.Files.Count];
+        fileGroup.Files.CopyTo(dataFiles, 0);
+        foreach (DataFile dataFile in dataFiles)
           dataFile.Rename(fileRelocation(dataFile.Name));
       }
-      LogFile[] array1 = new LogFile[db._database.LogFiles.Count];
-      db._database.LogFiles.CopyTo(array1, 0);
-      foreach (LogFile logFile in array1)
+      LogFile[] logFiles = new LogFile[db._database.LogFiles.Count];
+      db._database.LogFiles.CopyTo(logFiles, 0);
+      foreach (LogFile logFile in logFiles)
         logFile.Rename(fileRelocation(logFile.Name));
     }
 

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -225,28 +225,23 @@ namespace AgDatabaseMove.SmoFacade
         policy.Execute(() => restore.SqlRestore(_server));
         restore.Devices.Remove(backupDeviceItem);
       }
-
-      if (fileRelocation != null)
-        LogicalFileRename(databaseName, fileRelocation);
     }
 
-    private void LogicalFileRename(string databaseName, Func<string, string> fileRelocation)
+    public void LogicalFileRename(string databaseName, Func<string, string> fileRenamer)
     {
       var db = Database(databaseName);
-      if (db.Restoring)
-        db.RestoreWithRecovery();
 
-      foreach (FileGroup fileGroup in (SmoCollectionBase)db._database.FileGroups)
+      foreach (FileGroup fileGroup in db._database.FileGroups)
       {
-        DataFile[] dataFiles = new DataFile[fileGroup.Files.Count];
+        var dataFiles = new DataFile[fileGroup.Files.Count];
         fileGroup.Files.CopyTo(dataFiles, 0);
-        foreach (DataFile dataFile in dataFiles)
-          dataFile.Rename(fileRelocation(dataFile.Name));
+        foreach (var dataFile in dataFiles)
+          dataFile.Rename(fileRenamer(dataFile.Name));
       }
-      LogFile[] logFiles = new LogFile[db._database.LogFiles.Count];
+      var logFiles = new LogFile[db._database.LogFiles.Count];
       db._database.LogFiles.CopyTo(logFiles, 0);
-      foreach (LogFile logFile in logFiles)
-        logFile.Rename(fileRelocation(logFile.Name));
+      foreach (var logFile in logFiles)
+        logFile.Rename(fileRenamer(logFile.Name));
     }
 
     /// <summary>

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -224,10 +224,10 @@ namespace AgDatabaseMove.SmoFacade
 
         policy.Execute(() => restore.SqlRestore(_server));
         restore.Devices.Remove(backupDeviceItem);
-
-        if(fileRelocation != null)
-          LogicalFileRename(databaseName, fileRelocation);
       }
+
+      if (fileRelocation != null)
+        LogicalFileRename(databaseName, fileRelocation);
     }
 
     private void LogicalFileRename(string databaseName, Func<string, string> fileRelocation)

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -227,7 +227,7 @@ namespace AgDatabaseMove.SmoFacade
       }
     }
 
-    public void LogicalFileRename(string databaseName, Func<string, string> fileRenamer)
+    public void RenameLogicalFileName(string databaseName, Func<string, string> fileRenamer)
     {
       var db = Database(databaseName);
 


### PR DESCRIPTION
Made changes to `Restore` to rename logical files using `fileRelocator` when passed in.

Tested in separate console application, verified logical names had changed in SSMS