### PR TITLE
fix(backup-chain): next log backup can have the same `LastLsn`

### DIFF
--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -92,7 +92,9 @@ namespace AgDatabaseMove
     {
       // also gets all the stripes of the next backup
       return backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
-                                prevBackup.LastLsn >= b.FirstLsn && prevBackup.LastLsn <= b.LastLsn);
+                                prevBackup.LastLsn >= b.FirstLsn && 
+                                prevBackup.LastLsn <= b.LastLsn &&
+                                !new BackupEqualityComparer().Equals(prevBackup, b));
     }
 
     private static bool IsValidFilePath(BackupMetadata meta)

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -94,7 +94,7 @@ namespace AgDatabaseMove
       return backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
                                 prevBackup.LastLsn >= b.FirstLsn && 
                                 prevBackup.LastLsn <= b.LastLsn &&
-                                !new BackupEqualityComparer().Equals(prevBackup, b));
+                                !new BackupMetadataEqualityComparer().EqualsExceptForPhysicalDeviceName(prevBackup, b));
     }
 
     private static bool IsValidFilePath(BackupMetadata meta)

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -92,7 +92,7 @@ namespace AgDatabaseMove
     {
       // also gets all the stripes of the next backup
       return backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
-                                prevBackup.LastLsn >= b.FirstLsn && prevBackup.LastLsn + 1 < b.LastLsn);
+                                prevBackup.LastLsn >= b.FirstLsn && prevBackup.LastLsn <= b.LastLsn);
     }
 
     private static bool IsValidFilePath(BackupMetadata meta)

--- a/src/BackupMetadata.cs
+++ b/src/BackupMetadata.cs
@@ -5,12 +5,7 @@ namespace AgDatabaseMove
   using SmoFacade;
 
 
-  /// <summary>
-  ///   Occasionally we wind up with the same entry for a backup on multiple instance's msdb.
-  ///   For now we'll consider these backups to be equal despite their file location,
-  ///   but perhaps there's value in being able to look for the file in multiple locations.
-  /// </summary>
-  public class BackupMetadataEqualityComparer : IEqualityComparer<BackupMetadata>
+  public class BackupEqualityComparer : IEqualityComparer<BackupMetadata>
   {
     public bool Equals(BackupMetadata x, BackupMetadata y)
     {
@@ -18,18 +13,37 @@ namespace AgDatabaseMove
              x.FirstLsn == y.FirstLsn &&
              x.BackupType == y.BackupType &&
              x.DatabaseName == y.DatabaseName &&
-             x.PhysicalDeviceName == y.PhysicalDeviceName;
+             x.CheckpointLsn == y.CheckpointLsn &&
+             x.DatabaseBackupLsn == x.DatabaseBackupLsn;
     }
 
     public int GetHashCode(BackupMetadata obj)
     {
       var hashCode = -1277603921;
       hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.DatabaseName);
-      hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
       hashCode = hashCode * -1521134295 +
                  EqualityComparer<BackupFileTools.BackupType>.Default.GetHashCode(obj.BackupType);
       hashCode = hashCode * -1521134295 + obj.FirstLsn.GetHashCode();
       hashCode = hashCode * -1521134295 + obj.LastLsn.GetHashCode();
+      hashCode = hashCode * -1521134295 + obj.CheckpointLsn.GetHashCode();
+      hashCode = hashCode * -1521134295 + obj.DatabaseBackupLsn.GetHashCode();
+      return hashCode;
+    }
+  }
+
+  public class BackupMetadataEqualityComparer : IEqualityComparer<BackupMetadata>
+  {
+    public bool Equals(BackupMetadata x, BackupMetadata y)
+    {
+      return new BackupEqualityComparer()
+        .Equals(x, y)
+        && x.PhysicalDeviceName == y.PhysicalDeviceName;
+    }
+
+    public int GetHashCode(BackupMetadata obj)
+    {
+      var hashCode = new BackupEqualityComparer().GetHashCode(obj);
+      hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
       return hashCode;
     }
   }

--- a/src/BackupMetadata.cs
+++ b/src/BackupMetadata.cs
@@ -4,10 +4,13 @@ namespace AgDatabaseMove
   using System.Collections.Generic;
   using SmoFacade;
 
-
-  public class BackupEqualityComparer : IEqualityComparer<BackupMetadata>
+  public class BackupMetadataEqualityComparer : IEqualityComparer<BackupMetadata>
   {
-    public bool Equals(BackupMetadata x, BackupMetadata y)
+    /// <summary>
+    /// This is used for checking similar backups (like striped backups)
+    /// </summary>
+    /// <returns>bool</returns>
+    public bool EqualsExceptForPhysicalDeviceName(BackupMetadata x, BackupMetadata y)
     {
       return x.LastLsn == y.LastLsn &&
              x.FirstLsn == y.FirstLsn &&
@@ -17,33 +20,27 @@ namespace AgDatabaseMove
              x.DatabaseBackupLsn == x.DatabaseBackupLsn;
     }
 
+    /// <summary>
+    /// This is used for checking exactly the same backup (like finding duplicates)
+    /// </summary>
+    /// <returns>bool</returns>
+    public bool Equals(BackupMetadata x, BackupMetadata y)
+    {
+      return EqualsExceptForPhysicalDeviceName(x, y)
+        && x.PhysicalDeviceName == y.PhysicalDeviceName;
+    }
+
     public int GetHashCode(BackupMetadata obj)
     {
       var hashCode = -1277603921;
       hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.DatabaseName);
+      hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
       hashCode = hashCode * -1521134295 +
                  EqualityComparer<BackupFileTools.BackupType>.Default.GetHashCode(obj.BackupType);
       hashCode = hashCode * -1521134295 + obj.FirstLsn.GetHashCode();
       hashCode = hashCode * -1521134295 + obj.LastLsn.GetHashCode();
       hashCode = hashCode * -1521134295 + obj.CheckpointLsn.GetHashCode();
       hashCode = hashCode * -1521134295 + obj.DatabaseBackupLsn.GetHashCode();
-      return hashCode;
-    }
-  }
-
-  public class BackupMetadataEqualityComparer : IEqualityComparer<BackupMetadata>
-  {
-    public bool Equals(BackupMetadata x, BackupMetadata y)
-    {
-      return new BackupEqualityComparer()
-        .Equals(x, y)
-        && x.PhysicalDeviceName == y.PhysicalDeviceName;
-    }
-
-    public int GetHashCode(BackupMetadata obj)
-    {
-      var hashCode = new BackupEqualityComparer().GetHashCode(obj);
-      hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
       return hashCode;
     }
   }


### PR DESCRIPTION
(It looks like it made loads of white space changes automatically - pls ignore this while reviewing.)

I came across an instance where the `LastLsn` was the same for 2 backups. Hence, this check was filtering the log backup out.

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/24481933/166492356-22188969-705b-4949-a160-a0b95812665f.png">
