### PR TITLE
fix(move): rename logical file name

### DIFF
--- a/src/AgDatabaseMove.cs
+++ b/src/AgDatabaseMove.cs
@@ -82,7 +82,6 @@ namespace AgDatabaseMove
 
       if(_options.Finalize) {
         _options.Destination.JoinAg();
-        _options.Destination.RenameLogicalFileName(_options.FileRelocator);
       }
 
       return backupList.Max(bl => bl.LastLsn);


### PR DESCRIPTION
Need to remove this line.
We have some cases where we are trying to rename a file to itself, causing exceptions
