### PR TITLE
perf(AgDatabase): Delete

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -99,8 +99,15 @@ namespace AgDatabaseMove
     /// </summary>
     public void Delete()
     {
+      _listener.ForEachAgInstance((s, ag) => {
+        if (!ag.IsPrimaryInstance)
+        {
+          ag.Remove(Name);
+          s.Database(Name)?.Drop();
+        }
+      });
       _listener.AvailabilityGroup.Remove(Name);
-      _listener.ForEachAgInstance(s => s.Database(Name)?.Drop());
+      _listener.Primary.Database(Name)?.Drop();
     }
 
     /// <summary>

--- a/src/SmoFacade/AvailabilityGroup.cs
+++ b/src/SmoFacade/AvailabilityGroup.cs
@@ -57,7 +57,13 @@ namespace AgDatabaseMove.SmoFacade
 
     public void Remove(string dbName)
     {
-      _availabilityGroup.AvailabilityDatabases[dbName]?.Drop();
+      if (IsPrimaryInstance)
+      {
+        _availabilityGroup.AvailabilityDatabases[dbName]?.Drop();
+      } else
+      {
+        _availabilityGroup.AvailabilityDatabases[dbName]?.LeaveAvailabilityGroup();
+      }
     }
 
     public bool IsInitializing(string dbName)


### PR DESCRIPTION
I'd been experiencing issues with `Delete` while testing the changes I was making for creating databases. Specifically, despite the retry logic in place the method seemed to be throwing this [exception](https://github.com/factset/AgDatabaseMove/blob/43a0983f687358a669cf74ddb47b383ff21276a3/src/SmoFacade/Database.cs#L287-L289) on a high volume of invocations.

As I was investigating the cause I found this [post](https://stackoverflow.com/questions/27950110/smo-equivalent-to-set-hadr-off), which led me to believe our logic for leaving an availability group on secondary servers may be taking a needlessly lengthy amount of time.

Tested with the local `AgDatabaseMove.Cli` and found the database was able to drop successfully without throwing, all within ~4000 ms versus the old execution time ~30000 ms (when the method worked on the first invocation). 

I believe we currently have an additional retry policy surrounding the call to `Delete()` in one of our repositories. This change should remove the need to nest retry policies altogether.