### PR TITLE
fix(backupchain): diff and log share last lsn

### DIFF
--- a/src/AgDatabaseMove.cs
+++ b/src/AgDatabaseMove.cs
@@ -66,17 +66,15 @@ namespace AgDatabaseMove
       _options.Source.LogBackup();
 
       var backupChain = new BackupChain(_options.Source);
-      var backupList = backupChain.OrderedBackups.ToList();
+      var stripedBackupList = backupChain.OrderedBackups.ToList();
 
       if(_options.Destination.Restoring && lastLsn != null)
-        backupList.RemoveAll(b => b.LastLsn <= lastLsn.Value);
+        stripedBackupList.RemoveAll(b => b.LastLsn <= lastLsn.Value);
 
-      if(!backupList.Any())
+      if(!stripedBackupList.Any())
         throw new BackupChainException("No backups found to restore");
       
-      var stripedBackupSetChain = StripedBackupSet.GetStripedBackupSetChain(backupList);
-
-      _options.Destination.Restore(stripedBackupSetChain, _options.RetryDuration, _options.FileRelocator);
+      _options.Destination.Restore(stripedBackupList, _options.RetryDuration, _options.FileRelocator);
 
       if(_options.CopyLogins)
         foreach(var loginProperty in _options.Source.AssociatedLogins().Select(UpdateDefaultDb))
@@ -86,7 +84,7 @@ namespace AgDatabaseMove
         _options.Destination.JoinAg();
       }
 
-      return backupList.Max(bl => bl.LastLsn);
+      return stripedBackupList.Max(bl => bl.LastLsn);
     }
   }
 }

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -35,7 +35,7 @@ namespace AgDatabaseMove
       IEnumerable<BackupMetadata> nextLogBackups;
       while((nextLogBackups = NextLogBackup(backups, prevBackup)).Any()) {
         orderedBackups.AddRange(nextLogBackups);
-        prevBackup = orderedBackups.Last();
+        prevBackup = nextLogBackups.First();
       }
 
       _orderedBackups = orderedBackups;

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -8,7 +8,7 @@ namespace AgDatabaseMove
 
   public interface IBackupChain
   {
-    IEnumerable<BackupMetadata> OrderedBackups { get; }
+    IEnumerable<StripedBackup> OrderedBackups { get; }
   }
 
   /// <summary>
@@ -16,27 +16,32 @@ namespace AgDatabaseMove
   /// </summary>
   public class BackupChain : IBackupChain
   {
-    private readonly IList<BackupMetadata> _orderedBackups;
+    private readonly IList<StripedBackup> _orderedBackups;
 
     // This also handles any striped backups
-    private BackupChain(IList<BackupMetadata> recentBackups)
+    private BackupChain(IList<SingleBackup> recentBackups)
     {
       if(recentBackups == null || recentBackups.Count == 0)
         throw new BackupChainException("There are no recent backups to form a chain");
 
-      var backups = recentBackups.Distinct(BackupMetadataEqualityComparer.Instance)
-        .Where(IsValidFilePath) // A third party application caused invalid path strings to be inserted into backupmediafamily
-        .ToList();
+      var backups = recentBackups
+                    .Distinct(BackupMetadataEqualityComparer.Instance)
+                    .Where(IsValidFilePath); // A third party application caused invalid path strings to be inserted into backupmediafamily
+      var stripedBackups = StripedBackup.GetStripedBackupChain(backups);
 
-      var orderedBackups = MostRecentFullBackup(backups).ToList();
-      orderedBackups.AddRange(MostRecentDiffBackup(backups, orderedBackups.First()));
-      orderedBackups.AddRange(FirstLogBackupInChain(backups, orderedBackups.Last()));
+      var orderedBackups = new List<StripedBackup> { MostRecentFullBackup(stripedBackups) };
+      var diff = MostRecentDiffBackup(stripedBackups, orderedBackups.First());
+      if (diff != null) { orderedBackups.Add(diff); }
 
-      var prevBackup = orderedBackups.Last();
-      IEnumerable<BackupMetadata> nextLogBackups;
-      while((nextLogBackups = NextLogBackup(backups, prevBackup)).Any()) {
-        orderedBackups.AddRange(nextLogBackups);
-        prevBackup = orderedBackups.Last();
+      var nextLog = FirstLogInChain(stripedBackups, orderedBackups.Last());
+      if (nextLog != null) { 
+        orderedBackups.Add(nextLog);
+        var prevBackup = nextLog;
+        while ((nextLog = NextLogBackup(stripedBackups, prevBackup)) != null)
+        {
+          orderedBackups.Add(nextLog);
+          prevBackup = nextLog;
+        }
       }
 
       _orderedBackups = orderedBackups;
@@ -55,67 +60,45 @@ namespace AgDatabaseMove
     /// <summary>
     ///   Backups ordered to have a full restore chain.
     /// </summary>
-    public IEnumerable<BackupMetadata> OrderedBackups => _orderedBackups;
+    public IEnumerable<StripedBackup> OrderedBackups => _orderedBackups;
 
-    private static IEnumerable<BackupMetadata> MostRecentFullBackup(IEnumerable<BackupMetadata> backups)
+    private static StripedBackup MostRecentFullBackup(IEnumerable<StripedBackup> stripedBackups)
     {
-      var fullBackupsOrdered = backups
+      var fullBackupsOrdered = stripedBackups
         .Where(b => b.BackupType == BackupFileTools.BackupType.Full)
         .OrderByDescending(d => d.CheckpointLsn).ToList();
 
       if(!fullBackupsOrdered.Any())
         throw new BackupChainException("Could not find any full backups");
 
-      var targetCheckpointLsn = fullBackupsOrdered.First().CheckpointLsn;
-      // get all the stripes of this backup
-      return fullBackupsOrdered.Where(fullBackup => fullBackup.CheckpointLsn == targetCheckpointLsn);
+      return fullBackupsOrdered.First();
     }
 
-    private static IEnumerable<BackupMetadata> MostRecentDiffBackup(IEnumerable<BackupMetadata> backups,
+    private static StripedBackup MostRecentDiffBackup(IEnumerable<StripedBackup> stripedBackups,
       BackupMetadata lastFullBackup)
     {
-      var diffBackupsOrdered = backups
-        .Where(b =>
-                 b.BackupType == BackupFileTools.BackupType.Diff &&
-                 b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn)
-        .OrderByDescending(b => b.LastLsn).ToList();
-
-      if(!diffBackupsOrdered.Any())
-        return new List<BackupMetadata>();
-
-      var targetLastLsn = diffBackupsOrdered.First().LastLsn;
-      // get all the stripes of this backup
-      return diffBackupsOrdered.Where(diffBackup => diffBackup.LastLsn == targetLastLsn);
+      return stripedBackups.OrderByDescending(b => b.LastLsn)
+                    .FirstOrDefault(b => b.BackupType == BackupFileTools.BackupType.Diff 
+                                        && b.DatabaseBackupLsn == lastFullBackup.CheckpointLsn);
     }
 
-    private static IEnumerable<BackupMetadata> NextLogBackup(IEnumerable<BackupMetadata> backups,
-      BackupMetadata prevBackup)
+    private static StripedBackup NextLogBackup(IEnumerable<StripedBackup> stripedBackups,
+      BackupMetadata prevLog)
     {
-     // also gets all the stripes of the next backup
-     return backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
-                               prevBackup.LastLsn == b.FirstLsn &&
-                               !StripedBackupEqualityComparer.Instance.Equals(prevBackup, b));
+      return stripedBackups.SingleOrDefault(b => b.BackupType == BackupFileTools.BackupType.Log &&
+                                          prevLog.LastLsn == b.FirstLsn);
     }
 
-    private static IEnumerable<BackupMetadata> FirstLogBackupInChain(IEnumerable<BackupMetadata> backups, 
-     BackupMetadata lastDiff)
+    private static StripedBackup FirstLogInChain(IEnumerable<StripedBackup> stripedBackups, 
+     BackupMetadata lastBackup)
     {
-      var possibleLogs = backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
-                                       lastDiff.LastLsn >= b.FirstLsn &&
-                                       lastDiff.LastLsn <= b.LastLsn &&
-                                       !StripedBackupEqualityComparer.Instance.Equals(lastDiff, b));
+      return stripedBackups.OrderByDescending(b => b.LastLsn)
+        .FirstOrDefault(b => b.BackupType == BackupFileTools.BackupType.Log && 
+                             lastBackup.LastLsn >= b.FirstLsn &&
+                             lastBackup.LastLsn <= b.LastLsn);
+    }
 
-      var striped = StripedBackupSet.GetStripedBackupSetChain(possibleLogs);
-
-      if (striped.Count() > 1)
-      {
-       return striped.OrderBy(striped => striped.StripedBackups.First().LastLsn).Last().StripedBackups;
-      }
-
-      return possibleLogs;
-  }
-
-    private static bool IsValidFilePath(BackupMetadata meta)
+    private static bool IsValidFilePath(SingleBackup meta)
     {
       var path = meta.PhysicalDeviceName;
       return BackupFileTools.IsValidFileUrl(path) || BackupFileTools.IsValidFilePath(path);

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -30,7 +30,7 @@ namespace AgDatabaseMove
 
       var orderedBackups = MostRecentFullBackup(backups).ToList();
       orderedBackups.AddRange(MostRecentDiffBackup(backups, orderedBackups.First()));
-      orderedBackups.AddRange(FirstBackupInChain(backups, orderedBackups.Last()));
+      orderedBackups.AddRange(FirstLogBackupInChain(backups, orderedBackups.Last()));
 
       var prevBackup = orderedBackups.Last();
       IEnumerable<BackupMetadata> nextLogBackups;
@@ -97,7 +97,7 @@ namespace AgDatabaseMove
                                !StripedBackupEqualityComparer.Instance.Equals(prevBackup, b));
     }
 
-    private static IEnumerable<BackupMetadata> FirstBackupInChain(IEnumerable<BackupMetadata> backups, 
+    private static IEnumerable<BackupMetadata> FirstLogBackupInChain(IEnumerable<BackupMetadata> backups, 
      BackupMetadata lastDiff)
     {
       var possibleLogs = backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&

--- a/src/BackupChain.cs
+++ b/src/BackupChain.cs
@@ -35,7 +35,7 @@ namespace AgDatabaseMove
       IEnumerable<BackupMetadata> nextLogBackups;
       while((nextLogBackups = NextLogBackup(backups, prevBackup)).Any()) {
         orderedBackups.AddRange(nextLogBackups);
-        prevBackup = nextLogBackups.First();
+        prevBackup = orderedBackups.Last();
       }
 
       _orderedBackups = orderedBackups;
@@ -94,7 +94,8 @@ namespace AgDatabaseMove
       return backups.Where(b => b.BackupType == BackupFileTools.BackupType.Log &&
                                 prevBackup.LastLsn >= b.FirstLsn &&
                                 prevBackup.LastLsn <= b.LastLsn &&
-                                !StripedBackupEqualityComparer.Instance.Equals(prevBackup, b));
+                                !StripedBackupEqualityComparer.Instance.Equals(prevBackup, b))
+                    .OrderBy(b => b.LastLsn);
     }
 
     private static bool IsValidFilePath(BackupMetadata meta)

--- a/src/BackupMetadata.cs
+++ b/src/BackupMetadata.cs
@@ -5,13 +5,13 @@ namespace AgDatabaseMove
   using System.Linq;
   using SmoFacade;
 
-  public class StripedBackupEqualityComparer : IEqualityComparer<BackupMetadata>
+  public class StripedBackupEqualityComparer : IEqualityComparer<SingleBackup>
   {
     private static readonly Lazy<StripedBackupEqualityComparer> s_instance = new Lazy<StripedBackupEqualityComparer>(() => new StripedBackupEqualityComparer());
     private StripedBackupEqualityComparer() { }
     public static StripedBackupEqualityComparer Instance => s_instance.Value;
 
-    public bool Equals(BackupMetadata x, BackupMetadata y)
+    public bool Equals(SingleBackup x, SingleBackup y)
     {
       return x.LastLsn == y.LastLsn &&
              x.FirstLsn == y.FirstLsn &&
@@ -21,7 +21,7 @@ namespace AgDatabaseMove
              x.DatabaseBackupLsn == y.DatabaseBackupLsn;
     }
 
-    public int GetHashCode(BackupMetadata obj)
+    public int GetHashCode(SingleBackup obj)
     {
       var hashCode = -1277603921;
       hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.DatabaseName);
@@ -39,7 +39,7 @@ namespace AgDatabaseMove
   /// <summary>
   /// Two BackupMetadatas are the same, if they are like striped backups but also have the same `PhysicalDeviceName`
   /// </summary>
-  public class BackupMetadataEqualityComparer : IEqualityComparer<BackupMetadata>
+  public class BackupMetadataEqualityComparer : IEqualityComparer<SingleBackup>
   {
     private static readonly StripedBackupEqualityComparer _stripedBackupEqualityComparer = StripedBackupEqualityComparer.Instance;
 
@@ -47,13 +47,13 @@ namespace AgDatabaseMove
     private BackupMetadataEqualityComparer() { }
     public static BackupMetadataEqualityComparer Instance => s_instance.Value;
 
-    public bool Equals(BackupMetadata x, BackupMetadata y)
+    public bool Equals(SingleBackup x, SingleBackup y)
     {
       return _stripedBackupEqualityComparer.Equals(x, y)
         && x.PhysicalDeviceName == y.PhysicalDeviceName;
     }
 
-    public int GetHashCode(BackupMetadata obj)
+    public int GetHashCode(SingleBackup obj)
     {
       var hashCode = _stripedBackupEqualityComparer.GetHashCode(obj);
       hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(obj.PhysicalDeviceName);
@@ -64,14 +64,13 @@ namespace AgDatabaseMove
   /// <summary>
   ///   Metadata about backups from msdb.dbo.backupset and msdb.dbo.backupmediafamily
   /// </summary>
-  public class BackupMetadata : ICloneable
+  public abstract class BackupMetadata : ICloneable
   {
     public decimal CheckpointLsn { get; set; }
     public decimal DatabaseBackupLsn { get; set; }
     public string DatabaseName { get; set; }
     public decimal FirstLsn { get; set; }
     public decimal LastLsn { get; set; }
-    public string PhysicalDeviceName { get; set; }
     public string ServerName { get; set; }
     public DateTime StartTime { get; set; }
 
@@ -82,27 +81,46 @@ namespace AgDatabaseMove
     /// </summary>
     public BackupFileTools.BackupType BackupType { get; set; }
 
+    internal BackupMetadata() { }
+
+    internal BackupMetadata(BackupMetadata backup)
+    {
+      CheckpointLsn = backup.CheckpointLsn;
+      DatabaseBackupLsn = backup.DatabaseBackupLsn;
+      DatabaseName = backup.DatabaseName;
+      FirstLsn = backup.FirstLsn;
+      LastLsn = backup.LastLsn;
+      ServerName = backup.ServerName;
+      StartTime = backup.StartTime;
+      BackupType = backup.BackupType;
+    }
+
     // used during testing
     public object Clone()
     {
       return MemberwiseClone();
     }
+ }
+
+  public class SingleBackup : BackupMetadata
+  {
+    public string PhysicalDeviceName { get; set; }
   }
 
-  public class StripedBackupSet
+  public class StripedBackup : BackupMetadata
   {
-    public IEnumerable<BackupMetadata> StripedBackups { get; private set; }
+    public IEnumerable<SingleBackup> StripedBackups { get; }
 
-    private StripedBackupSet(IEnumerable<BackupMetadata> stripedBackups)
+    private StripedBackup(IEnumerable<SingleBackup> stripedBackups) : base(stripedBackups.First())
     {
       StripedBackups = stripedBackups;
     }
 
-    public static IEnumerable<StripedBackupSet> GetStripedBackupSetChain(IEnumerable<BackupMetadata> backups)
+    internal static IEnumerable<StripedBackup> GetStripedBackupChain(IEnumerable<SingleBackup> backups)
     {
       var chain = backups
         .GroupBy(b => b, StripedBackupEqualityComparer.Instance)
-        .Select(group => new StripedBackupSet(group));
+        .Select(group => new StripedBackup(group));
       return chain;
     }
   }

--- a/src/SmoFacade/Database.cs
+++ b/src/SmoFacade/Database.cs
@@ -107,9 +107,9 @@ namespace AgDatabaseMove.SmoFacade
     ///   Queries msdb on the instance for backups of this database.
     /// </summary>
     /// <returns>A list of backups known by msdb</returns>
-    public List<BackupMetadata> MostRecentBackupChain()
+    public List<SingleBackup> MostRecentBackupChain()
     {
-      var backups = new List<BackupMetadata>();
+      var backups = new List<SingleBackup>();
 
       var query = "SELECT s.database_name, m.physical_device_name, s.backup_start_date, s.first_lsn, s.last_lsn," +
                   "s.database_backup_lsn, s.checkpoint_lsn, s.[type] AS backup_type, s.server_name, s.recovery_model " +
@@ -134,7 +134,7 @@ namespace AgDatabaseMove.SmoFacade
 
       using var reader = cmd.ExecuteReader();
       while (reader.Read())
-        backups.Add(new BackupMetadata
+        backups.Add(new SingleBackup
         {
           CheckpointLsn = (decimal)reader["checkpoint_lsn"],
           DatabaseBackupLsn = (decimal)reader["database_backup_lsn"],
@@ -176,9 +176,9 @@ namespace AgDatabaseMove.SmoFacade
       return (decimal)lsnValue;
     }
 
-    public List<BackupMetadata> BackupChainFromLsn(decimal checkpointLsn)
+    public List<SingleBackup> BackupChainFromLsn(decimal checkpointLsn)
     {
-      var backups = new List<BackupMetadata>();
+      var backups = new List<SingleBackup>();
 
       var query = "SELECT s.database_name, m.physical_device_name, s.backup_start_date, s.first_lsn, s.last_lsn, " +
                   "s.database_backup_lsn, s.checkpoint_lsn, s.[type] AS backup_type, s.server_name, s.recovery_model " +
@@ -203,7 +203,7 @@ namespace AgDatabaseMove.SmoFacade
 
       using var reader = cmd.ExecuteReader();
       while (reader.Read())
-        backups.Add(new BackupMetadata
+        backups.Add(new SingleBackup
         {
           CheckpointLsn = (decimal)reader["checkpoint_lsn"],
           DatabaseBackupLsn = (decimal)reader["database_backup_lsn"],

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -178,7 +178,7 @@ namespace AgDatabaseMove.SmoFacade
     ///   wait
     /// </param>
     /// <param name="fileRelocation">Option for renaming files during the restore.</param>
-    public void Restore(IEnumerable<StripedBackupSet> stripedBackupSetChain, string databaseName,
+    public void Restore(IEnumerable<StripedBackup> stripedBackupSetChain, string databaseName,
       Func<int, TimeSpan> retryDurationProvider,
       Func<string, string> fileRelocation = null)
     {
@@ -214,9 +214,9 @@ namespace AgDatabaseMove.SmoFacade
     /// <summary>
     /// This is like adding the `FROM URL='&lt;backup file url&gt;'` to the RESTORE T-SQL command
     /// </summary>
-    private void AddBackupDeviceItemsToRestore(Restore restore, StripedBackupSet stripedBackupSet)
+    private void AddBackupDeviceItemsToRestore(Restore restore, StripedBackup stripedBackups)
     {
-      foreach (var stripedBackup in stripedBackupSet.StripedBackups)
+      foreach (var stripedBackup in stripedBackups.StripedBackups)
       {
         var physicalDeviceName = stripedBackup.PhysicalDeviceName;
         var device = BackupFileTools.IsValidFileUrl(physicalDeviceName) ? DeviceType.Url : DeviceType.File;

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -93,7 +93,8 @@ namespace AgDatabaseMove.Unit
       };
     }
 
-  public static List<BackupMetadata> GetBackupListSingleServer()
+  // Tests the case where Log1.LastLsn == Diff.LastLsn == Log2.FirstLsn
+  public static List<BackupMetadata> GetBackupListWhereDiffBetweenLogs()
   {
     return new List<BackupMetadata> {
       new BackupMetadata {
@@ -277,14 +278,14 @@ namespace AgDatabaseMove.Unit
     }
 
     [Fact]
-    public void SingleServerChainEquality()
+    public void DiffBetweenTwoLogs()
     {
-      var list = GetBackupListSingleServer();
+      var list = GetBackupListWhereDiffBetweenLogs();
       var agDb = new Mock<IAgDatabase>();
       agDb.Setup(db => db.RecentBackups()).Returns(list);
       var chain = new BackupChain(agDb.Object).OrderedBackups.ToList();
-      list.Reverse();
-      Assert.Equal(list, chain);
+      Assert.Equal(4, chain.Count());
+      VerifyListIsAValidBackupChain(chain);
     }
 
     // TODO: test skipping of logs if diff last LSN and log last LSN matches

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -1,293 +1,293 @@
 namespace AgDatabaseMove.Unit
 {
-	using System;
-	using System.Collections.Generic;
-	using System.Linq;
-	using Exceptions;
-	using Moq;
-	using SmoFacade;
-	using Xunit;
+  using System;
+  using System.Collections.Generic;
+  using System.Linq;
+  using Exceptions;
+  using Moq;
+  using SmoFacade;
+  using Xunit;
 
 
-	public class BackupOrder
-	{
-	public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
-		new object[] { GetBackupList() },
-		new object[] { GetBackupListWithStripes() },
-		new object[] { GetBackupListWithoutDiff() },
-		new object[] { GetBackupListWithoutLogs() }
-	};
+  public class BackupOrder
+  {
+    public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
+      new object[] { GetBackupList() },
+      new object[] { GetBackupListWithStripes() },
+      new object[] { GetBackupListWithoutDiff() },
+      new object[] { GetBackupListWithoutLogs() }
+    };
 
 
-	public static IEnumerable<object[]> NegativeTestData => new List<object[]> {
-		new object[] { GetBackupListWithoutFull() },
-		new object[] { new List<BackupMetadata>() }
-	};
+    public static IEnumerable<object[]> NegativeTestData => new List<object[]> {
+      new object[] { GetBackupListWithoutFull() },
+      new object[] { new List<BackupMetadata>() }
+    };
 
-	private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
-	{
-		var result = new List<BackupMetadata>();
-		list.ForEach(b => { result.Add((BackupMetadata)b.Clone()); });
-		result.Reverse();
-		return result;
-	}
+    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
+    {
+      var result = new List<BackupMetadata>();
+      list.ForEach(b => { result.Add((BackupMetadata)b.Clone()); });
+      result.Reverse();
+      return result;
+    }
 
-	public static List<BackupMetadata> GetBackupList()
-	{
-		return new List<BackupMetadata> {
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 126000000943800037,
-			CheckpointLsn = 126000000953600034,
-			FirstLsn = 126000000955200001,
-			LastLsn = 126000000955500001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
-			StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 126000000943800037,
-			CheckpointLsn = 126000000953600034,
-			FirstLsn = 126000000955800001,
-			LastLsn = 126000000965800001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerB",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
-			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Full,
-			DatabaseBackupLsn = 126000000882000037,
-			CheckpointLsn = 126000000943800037,
-			FirstLsn = 126000000936100001,
-			LastLsn = 126000000945500001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_200.full",
-			StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 126000000943800037,
-			CheckpointLsn = 126000000953600034,
-			FirstLsn = 126000000955500001,
-			LastLsn = 126000000955800001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerB",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
-			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Diff,
-			DatabaseBackupLsn = 126000000943800037,
-			CheckpointLsn = 126000000953600034,
-			FirstLsn = 126000000945600000,
-			LastLsn = 126000000955200001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
-			StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
-		}
-		};
-	}
+    public static List<BackupMetadata> GetBackupList()
+    {
+      return new List<BackupMetadata> {
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Log,
+          DatabaseBackupLsn = 126000000943800037,
+          CheckpointLsn = 126000000953600034,
+          FirstLsn = 126000000955200001,
+          LastLsn = 126000000955500001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerA",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
+          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
+        },
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Log,
+          DatabaseBackupLsn = 126000000943800037,
+          CheckpointLsn = 126000000953600034,
+          FirstLsn = 126000000955800001,
+          LastLsn = 126000000965800001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerB",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
+          StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+        },
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Full,
+          DatabaseBackupLsn = 126000000882000037,
+          CheckpointLsn = 126000000943800037,
+          FirstLsn = 126000000936100001,
+          LastLsn = 126000000945500001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerA",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_200.full",
+          StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
+        },
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Log,
+          DatabaseBackupLsn = 126000000943800037,
+          CheckpointLsn = 126000000953600034,
+          FirstLsn = 126000000955500001,
+          LastLsn = 126000000955800001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerB",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
+          StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+        },
+        new BackupMetadata {
+          BackupType = BackupFileTools.BackupType.Diff,
+          DatabaseBackupLsn = 126000000943800037,
+          CheckpointLsn = 126000000953600034,
+          FirstLsn = 126000000945600000,
+          LastLsn = 126000000955200001,
+          DatabaseName = "TestDb",
+          ServerName = "ServerA",
+          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
+          StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
+        }
+      };
+    }
 
-	public static List<BackupMetadata> GetBackupListSingleServer()
-	{
-		return new List<BackupMetadata> {
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 95000000019800037,
-			CheckpointLsn = 95000000037700002,
-			FirstLsn = 95000000037500001,
-			LastLsn = 95000000038000001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_819.trn",
-			StartTime = DateTime.Parse("2018-10-29 05:00:07.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 95000000019800037,
-			CheckpointLsn = 95000000037200002,
-			FirstLsn = 95000000037000001,
-			LastLsn = 95000000037500001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_040005_727.trn",
-			StartTime = DateTime.Parse("2018-10-29 04:00:06.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Log,
-			DatabaseBackupLsn = 95000000019800037,
-			CheckpointLsn = 95000000036700001,
-			FirstLsn = 95000000036200001,
-			LastLsn = 95000000037000001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_030006_620.trn",
-			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Diff,
-			DatabaseBackupLsn = 95000000019800037,
-			CheckpointLsn = 95000000036700001,
-			FirstLsn = 95000000036700001,
-			LastLsn = 95000000037000001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_887.diff",
-			StartTime = DateTime.Parse("2018-10-29 02:03:39.000")
-		},
-		new BackupMetadata {
-			BackupType = BackupFileTools.BackupType.Full,
-			DatabaseBackupLsn = 93000000021200037,
-			CheckpointLsn = 95000000019800037,
-			FirstLsn = 95000000019800037,
-			LastLsn = 95000000021500001,
-			DatabaseName = "TestDb",
-			ServerName = "ServerA",
-			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_815.full",
-			StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
-		}
-		};
-	}
+  public static List<BackupMetadata> GetBackupListSingleServer()
+  {
+    return new List<BackupMetadata> {
+      new BackupMetadata {
+        BackupType = BackupFileTools.BackupType.Log,
+        DatabaseBackupLsn = 95000000019800037,
+        CheckpointLsn = 95000000037700002,
+        FirstLsn = 95000000037500001,
+        LastLsn = 95000000038000001,
+        DatabaseName = "TestDb",
+        ServerName = "ServerA",
+        PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_819.trn",
+        StartTime = DateTime.Parse("2018-10-29 05:00:07.000")
+      },
+      new BackupMetadata {
+        BackupType = BackupFileTools.BackupType.Log,
+        DatabaseBackupLsn = 95000000019800037,
+        CheckpointLsn = 95000000037200002,
+        FirstLsn = 95000000037000001,
+        LastLsn = 95000000037500001,
+        DatabaseName = "TestDb",
+        ServerName = "ServerA",
+        PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_040005_727.trn",
+        StartTime = DateTime.Parse("2018-10-29 04:00:06.000")
+      },
+      new BackupMetadata {
+        BackupType = BackupFileTools.BackupType.Log,
+        DatabaseBackupLsn = 95000000019800037,
+        CheckpointLsn = 95000000036700001,
+        FirstLsn = 95000000036200001,
+        LastLsn = 95000000037000001,
+        DatabaseName = "TestDb",
+        ServerName = "ServerA",
+        PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_030006_620.trn",
+        StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+      },
+      new BackupMetadata {
+        BackupType = BackupFileTools.BackupType.Diff,
+        DatabaseBackupLsn = 95000000019800037,
+        CheckpointLsn = 95000000036700001,
+        FirstLsn = 95000000036700001,
+        LastLsn = 95000000037000001,
+        DatabaseName = "TestDb",
+        ServerName = "ServerA",
+        PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_887.diff",
+        StartTime = DateTime.Parse("2018-10-29 02:03:39.000")
+      },
+      new BackupMetadata {
+        BackupType = BackupFileTools.BackupType.Full,
+        DatabaseBackupLsn = 93000000021200037,
+        CheckpointLsn = 95000000019800037,
+        FirstLsn = 95000000019800037,
+        LastLsn = 95000000021500001,
+        DatabaseName = "TestDb",
+        ServerName = "ServerA",
+        PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_815.full",
+        StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
+      }
+    };
+  }
 
-	private static List<BackupMetadata> GetBackupListWithoutLogs()
-	{
-		var list = GetBackupList();
-		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
-		return list;
-	}
+  private static List<BackupMetadata> GetBackupListWithoutLogs()
+    {
+      var list = GetBackupList();
+      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
+      return list;
+    }
 
-	private static List<BackupMetadata> GetBackupListWithoutDiff()
-	{
-		var list = GetBackupList();
-		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
-		return list;
-	}
+    private static List<BackupMetadata> GetBackupListWithoutDiff()
+    {
+      var list = GetBackupList();
+      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
+      return list;
+    }
 
-	public static List<BackupMetadata> GetBackupListWithStripes()
-	{
-		var list = GetBackupList();
-		var listWithStripes = CloneBackupMetaDataList(list).ToList();
-		var listWithStripes2 = CloneBackupMetaDataList(list).ToList();
+    public static List<BackupMetadata> GetBackupListWithStripes()
+    {
+      var list = GetBackupList();
+      var listWithStripes = CloneBackupMetaDataList(list).ToList();
+      var listWithStripes2 = CloneBackupMetaDataList(list).ToList();
 
-		listWithStripes.ForEach(b => {
-		var path = b.PhysicalDeviceName.Split('.');
-		b.PhysicalDeviceName = $"{path[0]}_striped.{path[1]}";
-		});
+      listWithStripes.ForEach(b => {
+        var path = b.PhysicalDeviceName.Split('.');
+        b.PhysicalDeviceName = $"{path[0]}_striped.{path[1]}";
+      });
 
-		listWithStripes2.ForEach(b => {
-		var path = b.PhysicalDeviceName.Split('.');
-		b.PhysicalDeviceName = $"{path[0]}_striped2.{path[1]}";
-		});
+      listWithStripes2.ForEach(b => {
+        var path = b.PhysicalDeviceName.Split('.');
+        b.PhysicalDeviceName = $"{path[0]}_striped2.{path[1]}";
+      });
 
-		list.AddRange(listWithStripes);
-		list.AddRange(listWithStripes2);
-		return list;
-	}
+      list.AddRange(listWithStripes);
+      list.AddRange(listWithStripes2);
+      return list;
+    }
 
-	private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
-	{
-		var listWithStripes = GetBackupListWithStripes();
-		var duplicate = CloneBackupMetaDataList(listWithStripes);
-		listWithStripes.AddRange(duplicate);
-		return listWithStripes;
-	}
+    private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
+    {
+      var listWithStripes = GetBackupListWithStripes();
+      var duplicate = CloneBackupMetaDataList(listWithStripes);
+      listWithStripes.AddRange(duplicate);
+      return listWithStripes;
+    }
 
-	private static List<BackupMetadata> GetBackupListWithoutFull()
-	{
-		var list = GetBackupList();
-		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
-		return list;
-	}
+    private static List<BackupMetadata> GetBackupListWithoutFull()
+    {
+      var list = GetBackupList();
+      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
+      return list;
+    }
 
-	private static void VerifyListIsAValidBackupChain(List<BackupMetadata> backupChain)
-	{
-		bool foundFull, foundDiff, foundLog;
-		foundFull = foundDiff = foundLog = false;
-		BackupMetadata full = null;
-		BackupMetadata lastBackup = null;
+    private static void VerifyListIsAValidBackupChain(List<BackupMetadata> backupChain)
+    {
+      bool foundFull, foundDiff, foundLog;
+      foundFull = foundDiff = foundLog = false;
+      BackupMetadata full = null;
+      BackupMetadata lastBackup = null;
 
-		BackupMetadata currentBackup;
-		while((currentBackup = backupChain.FirstOrDefault()) != null) {
-		if(currentBackup.BackupType == BackupFileTools.BackupType.Full) {
-			Assert.True(!foundFull && !foundDiff && !foundLog);
-			foundFull = true;
-			full = currentBackup;
-		}
-		else if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
-			Assert.True(foundFull && !foundDiff && !foundLog);
-			Assert.Equal(full.CheckpointLsn, currentBackup.DatabaseBackupLsn);
-			Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
-			foundDiff = true;
-		}
-		else if(currentBackup.BackupType == BackupFileTools.BackupType.Log) {
-			Assert.True(foundFull);
-			Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
-			foundLog = true;
-		}
+      BackupMetadata currentBackup;
+      while((currentBackup = backupChain.FirstOrDefault()) != null) {
+        if(currentBackup.BackupType == BackupFileTools.BackupType.Full) {
+          Assert.True(!foundFull && !foundDiff && !foundLog);
+          foundFull = true;
+          full = currentBackup;
+        }
+        else if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
+          Assert.True(foundFull && !foundDiff && !foundLog);
+          Assert.Equal(full.CheckpointLsn, currentBackup.DatabaseBackupLsn);
+          Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
+          foundDiff = true;
+        }
+        else if(currentBackup.BackupType == BackupFileTools.BackupType.Log) {
+          Assert.True(foundFull);
+          Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
+          foundLog = true;
+        }
 
-		lastBackup = currentBackup;
-		backupChain.RemoveAll(b => b.LastLsn == currentBackup.LastLsn);
-		}
-	}
+        lastBackup = currentBackup;
+        backupChain.RemoveAll(b => b.LastLsn == currentBackup.LastLsn);
+      }
+    }
 
-	[Theory]
-	[MemberData(nameof(PositiveTestData))]
-	public void BackupChainIsCorrect(List<BackupMetadata> backupList)
-	{
-		var agDatabase = new Mock<IAgDatabase>();
-		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
-		var backupChain = new BackupChain(agDatabase.Object);
-		VerifyListIsAValidBackupChain(backupChain.OrderedBackups.ToList());
-	}
+    [Theory]
+    [MemberData(nameof(PositiveTestData))]
+    public void BackupChainIsCorrect(List<BackupMetadata> backupList)
+    {
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
+      var backupChain = new BackupChain(agDatabase.Object);
+      VerifyListIsAValidBackupChain(backupChain.OrderedBackups.ToList());
+    }
 
-	[Theory]
-	[MemberData(nameof(NegativeTestData))]
-	public void CanDetectBackupChainIsWrong(List<BackupMetadata> backupList)
-	{
-		var agDatabase = new Mock<IAgDatabase>();
-		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
-		Assert.Throws<BackupChainException>(() => new BackupChain(agDatabase.Object));
-	}
+    [Theory]
+    [MemberData(nameof(NegativeTestData))]
+    public void CanDetectBackupChainIsWrong(List<BackupMetadata> backupList)
+    {
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
+      Assert.Throws<BackupChainException>(() => new BackupChain(agDatabase.Object));
+    }
 
-	[Fact]
-	public void MissingLink()
-	{
-		var backups = GetBackupList().Where(b => b.FirstLsn != 126000000955200001).ToList();
-		var agDatabase = new Mock<IAgDatabase>();
-		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+    [Fact]
+    public void MissingLink()
+    {
+      var backups = GetBackupList().Where(b => b.FirstLsn != 126000000955200001).ToList();
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
 
-		var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-		Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
-		VerifyListIsAValidBackupChain(chain);
-	}
+      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+      Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
+      VerifyListIsAValidBackupChain(chain);
+    }
 
-	[Fact]
-	public void DuplicateFiles()
-	{
-		var backups = GetBackupListWithStripesAndDuplicates();
-		var agDatabase = new Mock<IAgDatabase>();
-		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
-		var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-		Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
-	}
+    [Fact]
+    public void DuplicateFiles()
+    {
+      var backups = GetBackupListWithStripesAndDuplicates();
+      var agDatabase = new Mock<IAgDatabase>();
+      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+      Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
+    }
 
-	[Fact]
-	public void SingleServerChainEqualityTest()
-	{
-		var list = GetBackupListSingleServer();
-		var agDb = new Mock<IAgDatabase>();
-		agDb.Setup(db => db.RecentBackups()).Returns(list);
-		var chain = new BackupChain(agDb.Object).OrderedBackups.ToList();
-		Assert.Equal(list.Count, chain.Count);
-	}
+    [Fact]
+    public void SingleServerChainSizeEquality()
+    {
+      var list = GetBackupListSingleServer();
+      var agDb = new Mock<IAgDatabase>();
+      agDb.Setup(db => db.RecentBackups()).Returns(list);
+      var chain = new BackupChain(agDb.Object).OrderedBackups.ToList();
+      Assert.Equal(list.Count, chain.Count);
+    }
 
-		// TODO: test skipping of logs if diff last LSN and log last LSN matches
-		// TODO: test skipping of logs between diffs
-		// TODO: test only keep last diff
-	}
+    // TODO: test skipping of logs if diff last LSN and log last LSN matches
+    // TODO: test skipping of logs between diffs
+    // TODO: test only keep last diff
+  }
 }

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -1,222 +1,293 @@
 namespace AgDatabaseMove.Unit
 {
-  using System;
-  using System.Collections.Generic;
-  using System.Linq;
-  using Exceptions;
-  using Moq;
-  using SmoFacade;
-  using Xunit;
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using Exceptions;
+	using Moq;
+	using SmoFacade;
+	using Xunit;
 
 
-  public class BackupOrder
-  {
-    public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
-      new object[] { GetBackupList() },
-      new object[] { GetBackupListWithStripes() },
-      new object[] { GetBackupListWithoutDiff() },
-      new object[] { GetBackupListWithoutLogs() }
-    };
+	public class BackupOrder
+	{
+	public static IEnumerable<object[]> PositiveTestData => new List<object[]> {
+		new object[] { GetBackupList() },
+		new object[] { GetBackupListWithStripes() },
+		new object[] { GetBackupListWithoutDiff() },
+		new object[] { GetBackupListWithoutLogs() }
+	};
 
 
-    public static IEnumerable<object[]> NegativeTestData => new List<object[]> {
-      new object[] { GetBackupListWithoutFull() },
-      new object[] { new List<BackupMetadata>() }
-    };
+	public static IEnumerable<object[]> NegativeTestData => new List<object[]> {
+		new object[] { GetBackupListWithoutFull() },
+		new object[] { new List<BackupMetadata>() }
+	};
 
-    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
-    {
-      var result = new List<BackupMetadata>();
-      list.ForEach(b => { result.Add((BackupMetadata)b.Clone()); });
-      result.Reverse();
-      return result;
-    }
+	private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
+	{
+		var result = new List<BackupMetadata>();
+		list.ForEach(b => { result.Add((BackupMetadata)b.Clone()); });
+		result.Reverse();
+		return result;
+	}
 
-    public static List<BackupMetadata> GetBackupList()
-    {
-      return new List<BackupMetadata> {
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955200001,
-          LastLsn = 126000000955500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
-          StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955800001,
-          LastLsn = 126000000965800001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerB",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
-          StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Full,
-          DatabaseBackupLsn = 126000000882000037,
-          CheckpointLsn = 126000000943800037,
-          FirstLsn = 126000000936100001,
-          LastLsn = 126000000945500001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_200.full",
-          StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Log,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000955500001,
-          LastLsn = 126000000955800001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerB",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
-          StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
-        },
-        new BackupMetadata {
-          BackupType = BackupFileTools.BackupType.Diff,
-          DatabaseBackupLsn = 126000000943800037,
-          CheckpointLsn = 126000000953600034,
-          FirstLsn = 126000000945600000,
-          LastLsn = 126000000955200001,
-          DatabaseName = "TestDb",
-          ServerName = "ServerA",
-          PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
-          StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
-        }
-      };
-    }
+	public static List<BackupMetadata> GetBackupList()
+	{
+		return new List<BackupMetadata> {
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 126000000943800037,
+			CheckpointLsn = 126000000953600034,
+			FirstLsn = 126000000955200001,
+			LastLsn = 126000000955500001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
+			StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 126000000943800037,
+			CheckpointLsn = 126000000953600034,
+			FirstLsn = 126000000955800001,
+			LastLsn = 126000000965800001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerB",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
+			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Full,
+			DatabaseBackupLsn = 126000000882000037,
+			CheckpointLsn = 126000000943800037,
+			FirstLsn = 126000000936100001,
+			LastLsn = 126000000945500001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_200.full",
+			StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 126000000943800037,
+			CheckpointLsn = 126000000953600034,
+			FirstLsn = 126000000955500001,
+			LastLsn = 126000000955800001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerB",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
+			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Diff,
+			DatabaseBackupLsn = 126000000943800037,
+			CheckpointLsn = 126000000953600034,
+			FirstLsn = 126000000945600000,
+			LastLsn = 126000000955200001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_780.diff",
+			StartTime = DateTime.Parse("2018-10-29 00:03:39.000")
+		}
+		};
+	}
 
-    private static List<BackupMetadata> GetBackupListWithoutLogs()
-    {
-      var list = GetBackupList();
-      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
-      return list;
-    }
+	public static List<BackupMetadata> GetBackupListSingleServer()
+	{
+		return new List<BackupMetadata> {
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 95000000019800037,
+			CheckpointLsn = 95000000037700002,
+			FirstLsn = 95000000037500001,
+			LastLsn = 95000000038000001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_819.trn",
+			StartTime = DateTime.Parse("2018-10-29 05:00:07.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 95000000019800037,
+			CheckpointLsn = 95000000037200002,
+			FirstLsn = 95000000037000001,
+			LastLsn = 95000000037500001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_040005_727.trn",
+			StartTime = DateTime.Parse("2018-10-29 04:00:06.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Log,
+			DatabaseBackupLsn = 95000000019800037,
+			CheckpointLsn = 95000000036700001,
+			FirstLsn = 95000000036200001,
+			LastLsn = 95000000037000001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_030006_620.trn",
+			StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Diff,
+			DatabaseBackupLsn = 95000000019800037,
+			CheckpointLsn = 95000000036700001,
+			FirstLsn = 95000000036700001,
+			LastLsn = 95000000037000001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_887.diff",
+			StartTime = DateTime.Parse("2018-10-29 02:03:39.000")
+		},
+		new BackupMetadata {
+			BackupType = BackupFileTools.BackupType.Full,
+			DatabaseBackupLsn = 93000000021200037,
+			CheckpointLsn = 95000000019800037,
+			FirstLsn = 95000000019800037,
+			LastLsn = 95000000021500001,
+			DatabaseName = "TestDb",
+			ServerName = "ServerA",
+			PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_815.full",
+			StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
+		}
+		};
+	}
 
-    private static List<BackupMetadata> GetBackupListWithoutDiff()
-    {
-      var list = GetBackupList();
-      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
-      return list;
-    }
+	private static List<BackupMetadata> GetBackupListWithoutLogs()
+	{
+		var list = GetBackupList();
+		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
+		return list;
+	}
 
-    public static List<BackupMetadata> GetBackupListWithStripes()
-    {
-      var list = GetBackupList();
-      var listWithStripes = CloneBackupMetaDataList(list).ToList();
-      var listWithStripes2 = CloneBackupMetaDataList(list).ToList();
+	private static List<BackupMetadata> GetBackupListWithoutDiff()
+	{
+		var list = GetBackupList();
+		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
+		return list;
+	}
 
-      listWithStripes.ForEach(b => {
-        var path = b.PhysicalDeviceName.Split('.');
-        b.PhysicalDeviceName = $"{path[0]}_striped.{path[1]}";
-      });
+	public static List<BackupMetadata> GetBackupListWithStripes()
+	{
+		var list = GetBackupList();
+		var listWithStripes = CloneBackupMetaDataList(list).ToList();
+		var listWithStripes2 = CloneBackupMetaDataList(list).ToList();
 
-      listWithStripes2.ForEach(b => {
-        var path = b.PhysicalDeviceName.Split('.');
-        b.PhysicalDeviceName = $"{path[0]}_striped2.{path[1]}";
-      });
+		listWithStripes.ForEach(b => {
+		var path = b.PhysicalDeviceName.Split('.');
+		b.PhysicalDeviceName = $"{path[0]}_striped.{path[1]}";
+		});
 
-      list.AddRange(listWithStripes);
-      list.AddRange(listWithStripes2);
-      return list;
-    }
+		listWithStripes2.ForEach(b => {
+		var path = b.PhysicalDeviceName.Split('.');
+		b.PhysicalDeviceName = $"{path[0]}_striped2.{path[1]}";
+		});
 
-    private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
-    {
-      var listWithStripes = GetBackupListWithStripes();
-      var duplicate = CloneBackupMetaDataList(listWithStripes);
-      listWithStripes.AddRange(duplicate);
-      return listWithStripes;
-    }
+		list.AddRange(listWithStripes);
+		list.AddRange(listWithStripes2);
+		return list;
+	}
 
-    private static List<BackupMetadata> GetBackupListWithoutFull()
-    {
-      var list = GetBackupList();
-      list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
-      return list;
-    }
+	private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
+	{
+		var listWithStripes = GetBackupListWithStripes();
+		var duplicate = CloneBackupMetaDataList(listWithStripes);
+		listWithStripes.AddRange(duplicate);
+		return listWithStripes;
+	}
 
-    private static void VerifyListIsAValidBackupChain(List<BackupMetadata> backupChain)
-    {
-      bool foundFull, foundDiff, foundLog;
-      foundFull = foundDiff = foundLog = false;
-      BackupMetadata full = null;
-      BackupMetadata lastBackup = null;
+	private static List<BackupMetadata> GetBackupListWithoutFull()
+	{
+		var list = GetBackupList();
+		list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
+		return list;
+	}
 
-      BackupMetadata currentBackup;
-      while((currentBackup = backupChain.FirstOrDefault()) != null) {
-        if(currentBackup.BackupType == BackupFileTools.BackupType.Full) {
-          Assert.True(!foundFull && !foundDiff && !foundLog);
-          foundFull = true;
-          full = currentBackup;
-        }
-        else if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
-          Assert.True(foundFull && !foundDiff && !foundLog);
-          Assert.Equal(full.CheckpointLsn, currentBackup.DatabaseBackupLsn);
-          Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
-          foundDiff = true;
-        }
-        else if(currentBackup.BackupType == BackupFileTools.BackupType.Log) {
-          Assert.True(foundFull);
-          Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
-          foundLog = true;
-        }
+	private static void VerifyListIsAValidBackupChain(List<BackupMetadata> backupChain)
+	{
+		bool foundFull, foundDiff, foundLog;
+		foundFull = foundDiff = foundLog = false;
+		BackupMetadata full = null;
+		BackupMetadata lastBackup = null;
 
-        lastBackup = currentBackup;
-        backupChain.RemoveAll(b => b.LastLsn == currentBackup.LastLsn);
-      }
-    }
+		BackupMetadata currentBackup;
+		while((currentBackup = backupChain.FirstOrDefault()) != null) {
+		if(currentBackup.BackupType == BackupFileTools.BackupType.Full) {
+			Assert.True(!foundFull && !foundDiff && !foundLog);
+			foundFull = true;
+			full = currentBackup;
+		}
+		else if(currentBackup.BackupType == BackupFileTools.BackupType.Diff) {
+			Assert.True(foundFull && !foundDiff && !foundLog);
+			Assert.Equal(full.CheckpointLsn, currentBackup.DatabaseBackupLsn);
+			Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
+			foundDiff = true;
+		}
+		else if(currentBackup.BackupType == BackupFileTools.BackupType.Log) {
+			Assert.True(foundFull);
+			Assert.True(currentBackup.FirstLsn >= lastBackup.LastLsn);
+			foundLog = true;
+		}
 
-    [Theory]
-    [MemberData(nameof(PositiveTestData))]
-    public void BackupChainIsCorrect(List<BackupMetadata> backupList)
-    {
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
-      var backupChain = new BackupChain(agDatabase.Object);
-      VerifyListIsAValidBackupChain(backupChain.OrderedBackups.ToList());
-    }
+		lastBackup = currentBackup;
+		backupChain.RemoveAll(b => b.LastLsn == currentBackup.LastLsn);
+		}
+	}
 
-    [Theory]
-    [MemberData(nameof(NegativeTestData))]
-    public void CanDetectBackupChainIsWrong(List<BackupMetadata> backupList)
-    {
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
-      Assert.Throws<BackupChainException>(() => new BackupChain(agDatabase.Object));
-    }
+	[Theory]
+	[MemberData(nameof(PositiveTestData))]
+	public void BackupChainIsCorrect(List<BackupMetadata> backupList)
+	{
+		var agDatabase = new Mock<IAgDatabase>();
+		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
+		var backupChain = new BackupChain(agDatabase.Object);
+		VerifyListIsAValidBackupChain(backupChain.OrderedBackups.ToList());
+	}
 
-    [Fact]
-    public void MissingLink()
-    {
-      var backups = GetBackupList().Where(b => b.FirstLsn != 126000000955200001).ToList();
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+	[Theory]
+	[MemberData(nameof(NegativeTestData))]
+	public void CanDetectBackupChainIsWrong(List<BackupMetadata> backupList)
+	{
+		var agDatabase = new Mock<IAgDatabase>();
+		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
+		Assert.Throws<BackupChainException>(() => new BackupChain(agDatabase.Object));
+	}
 
-      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-      Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
-      VerifyListIsAValidBackupChain(chain);
-    }
+	[Fact]
+	public void MissingLink()
+	{
+		var backups = GetBackupList().Where(b => b.FirstLsn != 126000000955200001).ToList();
+		var agDatabase = new Mock<IAgDatabase>();
+		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
 
-    [Fact]
-    public void DuplicateFiles()
-    {
-      var backups = GetBackupListWithStripesAndDuplicates();
-      var agDatabase = new Mock<IAgDatabase>();
-      agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
-      var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-      Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
-    }
+		var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+		Assert.NotEqual(chain.Last().LastLsn, GetBackupList().Max(b => b.LastLsn));
+		VerifyListIsAValidBackupChain(chain);
+	}
 
-    // TODO: test skipping of logs if diff last LSN and log last LSN matches
-    // TODO: test skipping of logs between diffs
-    // TODO: test only keep last diff
-  }
+	[Fact]
+	public void DuplicateFiles()
+	{
+		var backups = GetBackupListWithStripesAndDuplicates();
+		var agDatabase = new Mock<IAgDatabase>();
+		agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
+		var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
+		Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
+	}
+
+	[Fact]
+	public void SingleServerChainEqualityTest()
+	{
+		var list = GetBackupListSingleServer();
+		var agDb = new Mock<IAgDatabase>();
+		agDb.Setup(db => db.RecentBackups()).Returns(list);
+		var chain = new BackupChain(agDb.Object).OrderedBackups.ToList();
+		Assert.Equal(list.Count, chain.Count);
+	}
+
+		// TODO: test skipping of logs if diff last LSN and log last LSN matches
+		// TODO: test skipping of logs between diffs
+		// TODO: test only keep last diff
+	}
 }

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -277,13 +277,14 @@ namespace AgDatabaseMove.Unit
     }
 
     [Fact]
-    public void SingleServerChainSizeEquality()
+    public void SingleServerChainEquality()
     {
       var list = GetBackupListSingleServer();
       var agDb = new Mock<IAgDatabase>();
       agDb.Setup(db => db.RecentBackups()).Returns(list);
       var chain = new BackupChain(agDb.Object).OrderedBackups.ToList();
-      Assert.Equal(list.Count, chain.Count);
+      list.Reverse();
+      Assert.Equal(list, chain);
     }
 
     // TODO: test skipping of logs if diff last LSN and log last LSN matches

--- a/tests/AgDatabaseMove.Unit/BackupOrder.cs
+++ b/tests/AgDatabaseMove.Unit/BackupOrder.cs
@@ -21,21 +21,21 @@ namespace AgDatabaseMove.Unit
 
     public static IEnumerable<object[]> NegativeTestData => new List<object[]> {
       new object[] { GetBackupListWithoutFull() },
-      new object[] { new List<BackupMetadata>() }
+      new object[] { new List<SingleBackup>() }
     };
 
-    private static IEnumerable<BackupMetadata> CloneBackupMetaDataList(List<BackupMetadata> list)
+    private static IEnumerable<SingleBackup> CloneBackupMetaDataList(List<SingleBackup> list)
     {
-      var result = new List<BackupMetadata>();
-      list.ForEach(b => { result.Add((BackupMetadata)b.Clone()); });
+      var result = new List<SingleBackup>();
+      list.ForEach(b => { result.Add((SingleBackup)b.Clone()); });
       result.Reverse();
       return result;
     }
 
-    public static List<BackupMetadata> GetBackupList()
+    public static List<SingleBackup> GetBackupList()
     {
-      return new List<BackupMetadata> {
-        new BackupMetadata {
+      return new List<SingleBackup> {
+        new SingleBackup {
           BackupType = BackupFileTools.BackupType.Log,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
@@ -46,7 +46,7 @@ namespace AgDatabaseMove.Unit
           PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_343.trn",
           StartTime = DateTime.Parse("2018-10-29 02:00:07.000")
         },
-        new BackupMetadata {
+        new SingleBackup {
           BackupType = BackupFileTools.BackupType.Log,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
@@ -57,7 +57,7 @@ namespace AgDatabaseMove.Unit
           PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_040005_900.trn",
           StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
         },
-        new BackupMetadata {
+        new SingleBackup {
           BackupType = BackupFileTools.BackupType.Full,
           DatabaseBackupLsn = 126000000882000037,
           CheckpointLsn = 126000000943800037,
@@ -68,7 +68,7 @@ namespace AgDatabaseMove.Unit
           PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_28_000227_200.full",
           StartTime = DateTime.Parse("2018-10-28 00:02:28.000")
         },
-        new BackupMetadata {
+        new SingleBackup {
           BackupType = BackupFileTools.BackupType.Log,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
@@ -79,7 +79,7 @@ namespace AgDatabaseMove.Unit
           PhysicalDeviceName = @"\\DFS\BACKUP\ServerB\testDb\Testdb_backup_2018_10_29_030006_660.trn",
           StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
         },
-        new BackupMetadata {
+        new SingleBackup {
           BackupType = BackupFileTools.BackupType.Diff,
           DatabaseBackupLsn = 126000000943800037,
           CheckpointLsn = 126000000953600034,
@@ -94,10 +94,10 @@ namespace AgDatabaseMove.Unit
     }
 
   // Tests the case where Log1.LastLsn == Diff.LastLsn == Log2.FirstLsn
-  public static List<BackupMetadata> GetBackupListWhereDiffBetweenLogs()
+  public static List<SingleBackup> GetBackupListWhereDiffBetweenLogs()
   {
-    return new List<BackupMetadata> {
-      new BackupMetadata {
+    return new List<SingleBackup> {
+      new SingleBackup {
         BackupType = BackupFileTools.BackupType.Log,
         DatabaseBackupLsn = 95000000019800037,
         CheckpointLsn = 95000000037700002,
@@ -108,7 +108,7 @@ namespace AgDatabaseMove.Unit
         PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_020007_819.trn",
         StartTime = DateTime.Parse("2018-10-29 05:00:07.000")
       },
-      new BackupMetadata {
+      new SingleBackup {
         BackupType = BackupFileTools.BackupType.Log,
         DatabaseBackupLsn = 95000000019800037,
         CheckpointLsn = 95000000037200002,
@@ -119,7 +119,7 @@ namespace AgDatabaseMove.Unit
         PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_040005_727.trn",
         StartTime = DateTime.Parse("2018-10-29 04:00:06.000")
       },
-      new BackupMetadata {
+      new SingleBackup {
         BackupType = BackupFileTools.BackupType.Log,
         DatabaseBackupLsn = 95000000019800037,
         CheckpointLsn = 95000000036700001,
@@ -130,7 +130,7 @@ namespace AgDatabaseMove.Unit
         PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_030006_620.trn",
         StartTime = DateTime.Parse("2018-10-29 03:00:06.000")
       },
-      new BackupMetadata {
+      new SingleBackup {
         BackupType = BackupFileTools.BackupType.Diff,
         DatabaseBackupLsn = 95000000019800037,
         CheckpointLsn = 95000000036700001,
@@ -141,7 +141,7 @@ namespace AgDatabaseMove.Unit
         PhysicalDeviceName = @"\\DFS\BACKUP\ServerA\testDb\Testdb_backup_2018_10_29_000339_887.diff",
         StartTime = DateTime.Parse("2018-10-29 02:03:39.000")
       },
-      new BackupMetadata {
+      new SingleBackup {
         BackupType = BackupFileTools.BackupType.Full,
         DatabaseBackupLsn = 93000000021200037,
         CheckpointLsn = 95000000019800037,
@@ -155,21 +155,21 @@ namespace AgDatabaseMove.Unit
     };
   }
 
-  private static List<BackupMetadata> GetBackupListWithoutLogs()
+  private static List<SingleBackup> GetBackupListWithoutLogs()
     {
       var list = GetBackupList();
       list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Log);
       return list;
     }
 
-    private static List<BackupMetadata> GetBackupListWithoutDiff()
+    private static List<SingleBackup> GetBackupListWithoutDiff()
     {
       var list = GetBackupList();
       list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Diff);
       return list;
     }
 
-    public static List<BackupMetadata> GetBackupListWithStripes()
+    public static List<SingleBackup> GetBackupListWithStripes()
     {
       var list = GetBackupList();
       var listWithStripes = CloneBackupMetaDataList(list).ToList();
@@ -190,7 +190,7 @@ namespace AgDatabaseMove.Unit
       return list;
     }
 
-    private static List<BackupMetadata> GetBackupListWithStripesAndDuplicates()
+    private static List<SingleBackup> GetBackupListWithStripesAndDuplicates()
     {
       var listWithStripes = GetBackupListWithStripes();
       var duplicate = CloneBackupMetaDataList(listWithStripes);
@@ -198,21 +198,22 @@ namespace AgDatabaseMove.Unit
       return listWithStripes;
     }
 
-    private static List<BackupMetadata> GetBackupListWithoutFull()
+    private static List<SingleBackup> GetBackupListWithoutFull()
     {
       var list = GetBackupList();
       list.RemoveAll(b => b.BackupType == BackupFileTools.BackupType.Full);
       return list;
     }
 
-    private static void VerifyListIsAValidBackupChain(List<BackupMetadata> backupChain)
+    private static void VerifyListIsAValidBackupChain(List<StripedBackup> backupChain)
     {
+      Assert.True(backupChain.Any());
       bool foundFull, foundDiff, foundLog;
       foundFull = foundDiff = foundLog = false;
-      BackupMetadata full = null;
-      BackupMetadata lastBackup = null;
+      StripedBackup full = null;
+      StripedBackup lastBackup = null;
+      StripedBackup currentBackup;
 
-      BackupMetadata currentBackup;
       while((currentBackup = backupChain.FirstOrDefault()) != null) {
         if(currentBackup.BackupType == BackupFileTools.BackupType.Full) {
           Assert.True(!foundFull && !foundDiff && !foundLog);
@@ -238,7 +239,7 @@ namespace AgDatabaseMove.Unit
 
     [Theory]
     [MemberData(nameof(PositiveTestData))]
-    public void BackupChainIsCorrect(List<BackupMetadata> backupList)
+    public void BackupChainIsCorrect(List<SingleBackup> backupList)
     {
       var agDatabase = new Mock<IAgDatabase>();
       agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
@@ -248,7 +249,7 @@ namespace AgDatabaseMove.Unit
 
     [Theory]
     [MemberData(nameof(NegativeTestData))]
-    public void CanDetectBackupChainIsWrong(List<BackupMetadata> backupList)
+    public void CanDetectBackupChainIsWrong(List<SingleBackup> backupList)
     {
       var agDatabase = new Mock<IAgDatabase>();
       agDatabase.Setup(agd => agd.RecentBackups()).Returns(backupList);
@@ -274,7 +275,7 @@ namespace AgDatabaseMove.Unit
       var agDatabase = new Mock<IAgDatabase>();
       agDatabase.Setup(agd => agd.RecentBackups()).Returns(backups);
       var chain = new BackupChain(agDatabase.Object).OrderedBackups.ToList();
-      Assert.Equal(backups.GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
+      Assert.Equal(backups.Distinct(StripedBackupEqualityComparer.Instance).GroupBy(b => b.PhysicalDeviceName).Count(), chain.Count);
     }
 
     [Fact]

--- a/tests/AgDatabaseMove.Unit/StripedBackupSetTests.cs
+++ b/tests/AgDatabaseMove.Unit/StripedBackupSetTests.cs
@@ -17,7 +17,7 @@ namespace AgDatabaseMove.Unit
     {
       var backupChain = BackupOrder.GetBackupListWithStripes();
 
-      var stripedBackupSetChain = StripedBackupSet.GetStripedBackupSetChain(backupChain);
+      var stripedBackupSetChain = StripedBackup.GetStripedBackupChain(backupChain);
 
       Assert.Equal(backupChain.Distinct(stripedBackupComparer).Count(), stripedBackupSetChain.Count());
     }
@@ -26,7 +26,7 @@ namespace AgDatabaseMove.Unit
     public void DoesntCombineNonStripedBackups()
     {
       var backupChain = BackupOrder.GetBackupList();
-      var stripedBackupSetChain = StripedBackupSet.GetStripedBackupSetChain(backupChain);
+      var stripedBackupSetChain = StripedBackup.GetStripedBackupChain(backupChain);
 
       Assert.Equal(backupChain.Count, stripedBackupSetChain.Count());
     }
@@ -37,7 +37,7 @@ namespace AgDatabaseMove.Unit
       var backupChain = BackupOrder.GetBackupListWithStripes();
     
 
-      var stripedBackupSetChain = StripedBackupSet.GetStripedBackupSetChain(backupChain);
+      var stripedBackupSetChain = StripedBackup.GetStripedBackupChain(backupChain);
 
       foreach (var stripedBackupSet in stripedBackupSetChain)
       {


### PR DESCRIPTION
I was running into an error with the backup chain construction on a sample of backups identical (in their order) to the example I've provided below as a unit test. I've included a fix in here that passes the provided unit test, but wanted to get additional eyes on this to verify the change shouldn't effect how backups are being ordered in other use cases.

Specifically, the variables used within the `while` loop would change as follows:

First Iteration
----
`orderedBackups `= [full, diff]
`prevBackup `= diff

`nextLog `= [log2, log1]

Second Iteration
----
`orderedBackups `= [full, diff, log2, log1]
`prevBackup `= log1

`nextLog `= [log2]

....

Such that the resulting `orderedBackups` = [full, diff, log2, log1, log2, ...]. This would result in a bug in which a striped backup chain built from these backups would incorrectly identify both log2 elements as part of a single striped backup instead of duplicates.
