### PR TITLE
fix(path): separators

### DIFF
--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -64,5 +64,17 @@
         return false;
       }
     }
+
+    public static string Combine(string path1, string path2)
+    {
+      if (string.IsNullOrEmpty(path1)) { return path2; }
+      if (string.IsNullOrEmpty(path2)) { return path1; }
+
+      // assumes path1 contains desired separators
+      var separator = path1.Contains(@"\") ? @"\" : "/";
+      return path1.EndsWith(separator) && path2.StartsWith(separator) ? 
+        $"{path1}{path2.Substring(1)}" :
+        path1.EndsWith(separator) || path2.StartsWith(separator) ? $"{path1}{path2}" : $"{path1}{separator}{path2}";
+    }
   }
 }

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -72,9 +72,9 @@
 
       // assumes path1 contains desired separators
       var separator = path1.Contains(@"\") ? @"\" : "/";
-      return path1.EndsWith(separator) && path2.StartsWith(separator) ? 
-        $"{path1}{path2.Substring(1)}" :
-        path1.EndsWith(separator) || path2.StartsWith(separator) ? $"{path1}{path2}" : $"{path1}{separator}{path2}";
+      var path = path1.EndsWith(separator) ? path1.Substring(0, path1.Length - 1) : path1;
+      var file = path2.StartsWith(separator) ? path2.Substring(1) : path2;
+      return $"{path}{separator}{file}";
     }
   }
 }

--- a/src/SmoFacade/BackupFileTools.cs
+++ b/src/SmoFacade/BackupFileTools.cs
@@ -65,7 +65,7 @@
       }
     }
 
-    public static string Combine(string path1, string path2)
+    public static string CombinePaths(string path1, string path2)
     {
       if (string.IsNullOrEmpty(path1)) { return path2; }
       if (string.IsNullOrEmpty(path2)) { return path1; }

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -247,7 +247,7 @@ namespace AgDatabaseMove.SmoFacade
         var path = (string)file["Type"] == "L" ? defaultFileLocations?.Log : defaultFileLocations?.Data;
         path ??= Path.GetFullPath(physicalName);
 
-        var newFilePath = BackupFileTools.Combine(path, fileName);
+        var newFilePath = BackupFileTools.CombinePaths(path, fileName);
 
         restore.RelocateFiles.Add(new RelocateFile((string)file["LogicalName"], newFilePath));
       }

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -247,7 +247,7 @@ namespace AgDatabaseMove.SmoFacade
         var path = (string)file["Type"] == "L" ? defaultFileLocations?.Log : defaultFileLocations?.Data;
         path ??= Path.GetFullPath(physicalName);
 
-        var newFilePath = Path.Combine(path, fileName);
+        var newFilePath = BackupFileTools.Combine(path, fileName);
 
         restore.RelocateFiles.Add(new RelocateFile((string)file["LogicalName"], newFilePath));
       }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -79,9 +79,32 @@ namespace AgDatabaseMove.Unit
     [InlineData(@"C:\dir")]
     [InlineData(@"C:\")]
     [InlineData(@"C:\inval|d")]
+    [InlineData(@"C:\is\not/valid")]
+    [InlineData(@"C:/is/not\valid")]
+    [InlineData(@"C:\is\not\/valid")]
+    [InlineData(@"C:/is/not/\valid")]
     public void InValidPathTests(string path)
     {
       Assert.False(BackupFileTools.IsValidFilePath(path));
     }
+
+    [Theory]
+    [InlineData("", "C:\\dir\\file.ext", "C:\\dir\\file.ext")]
+    [InlineData("C:\\dir\\file.ext", "", "C:\\dir\\file.ext")]
+    [InlineData("", "C:/dir/file.ext", "C:/dir/file.ext")]
+    [InlineData("C:/dir/file.ext", "", "C:/dir/file.ext")]
+    [InlineData("C:\\dir\\", "file.ext", "C:\\dir\\file.ext")]
+    [InlineData("C:/dir/", "file.ext", "C:/dir/file.ext")]
+    [InlineData("C:\\dir", "file.ext", "C:\\dir\\file.ext")]
+    [InlineData("C:/dir", "file.ext", "C:/dir/file.ext")]
+    [InlineData("C:/dir", "/file.ext", "C:/dir/file.ext")]
+    [InlineData("C:\\dir", "\\file.ext", "C:\\dir\\file.ext")]
+    [InlineData("C:/dir/", "/file.ext", "C:/dir/file.ext")]
+    [InlineData("C:\\dir\\", "\\file.ext", "C:\\dir\\file.ext")]
+    public void CombineTests(string path, string file, string answer)
+    {
+      Assert.Equal(answer, BackupFileTools.Combine(path, file));
+    }
+
   }
 }

--- a/tests/AgDatabaseMove.Unit/FileToolsTest.cs
+++ b/tests/AgDatabaseMove.Unit/FileToolsTest.cs
@@ -103,7 +103,7 @@ namespace AgDatabaseMove.Unit
     [InlineData("C:\\dir\\", "\\file.ext", "C:\\dir\\file.ext")]
     public void CombineTests(string path, string file, string answer)
     {
-      Assert.Equal(answer, BackupFileTools.Combine(path, file));
+      Assert.Equal(answer, BackupFileTools.CombinePaths(path, file));
     }
 
   }


### PR DESCRIPTION
Quick and easy alternative to relying on `System.IO.Path` file separators.