### PR TITLE
feat(Restore): single backup

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -34,6 +34,9 @@ namespace AgDatabaseMove
     void Restore(IEnumerable<StripedBackup> stripedBackupChain, Func<int, TimeSpan> retryDurationProvider,
       Func<string, string> fileRelocation = null);
 
+    void Restore(SingleBackup fullBackup, Func<int, TimeSpan> retryDurationProvider,
+      Func<string, string> fileRelocation = null);
+
     void RenameLogicalFileName(Func<string, string> fileRenamer);
     void AddLogin(LoginProperties login);
     IEnumerable<LoginProperties> AssociatedLogins();
@@ -129,6 +132,12 @@ namespace AgDatabaseMove
       Func<string, string> fileRelocation = null)
     {
       _listener.ForEachAgInstance(s => s.Restore(stripedBackupChain, Name, retryDurationProvider, fileRelocation));
+    }
+
+    public void Restore(SingleBackup fullBackup, Func<int, TimeSpan> retryDurationProvider,
+      Func<string, string> fileRelocation = null)
+    {
+      _listener.ForEachAgInstance(s => s.Restore(fullBackup, Name, retryDurationProvider, fileRelocation));
     }
 
     public void RenameLogicalFileName(Func<string, string> fileRenamer)

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -137,6 +137,8 @@ namespace AgDatabaseMove
     public void Restore(SingleBackup fullBackup, Func<int, TimeSpan> retryDurationProvider,
       Func<string, string> fileRelocation = null)
     {
+      if(fullBackup.BackupType != BackupFileTools.BackupType.Full)
+        throw new ArgumentException("Provided backup must be a full database backup.");
       _listener.ForEachAgInstance(s => s.Restore(fullBackup, Name, retryDurationProvider, fileRelocation));
     }
 

--- a/tests/AgDatabaseMove.Integration/TestRestore.cs
+++ b/tests/AgDatabaseMove.Integration/TestRestore.cs
@@ -206,5 +206,16 @@ namespace AgDatabaseMove.Integration
 
       Test.Delete();
     }
-  }
+
+    [Fact]
+    public void TestThrowsIfBackupNotFull()
+    {
+      var logBackup = new SingleBackup { PhysicalDeviceName = Config.FullBackup, BackupType = BackupFileTools.BackupType.Log };
+      var diffBackup = new SingleBackup { PhysicalDeviceName = Config.FullBackup, BackupType = BackupFileTools.BackupType.Diff };
+      Func<int, TimeSpan> retryDurationProvider = attempt => TimeSpan.FromSeconds(10 * attempt);
+
+      Assert.Throws<ArgumentException>(() => Test.Restore(logBackup, retryDurationProvider));
+      Assert.Throws<ArgumentException>(() => Test.Restore(diffBackup, retryDurationProvider));
+    }
+ }
 }


### PR DESCRIPTION
Created an overload for `Restore` that takes in a full `SingleBackup`. This can be used to restore databases that can be effectively recovered under the simple recovery model. Added a couple integration tests and verified they passed. 