### PR TITLE
feat(IListener): visibility

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -23,6 +23,7 @@ namespace AgDatabaseMove
 
   public interface IAgDatabase
   {
+    IListener Listener { get; }
     bool Restoring { get; }
     string Name { get; }
     bool Exists();
@@ -78,6 +79,8 @@ namespace AgDatabaseMove
     public decimal SizeMb => _listener.Primary.DatabaseSizeMb(Name);
 
     public int ServerRemainingDiskMb => _listener.Primary.RemainingDiskMb();
+
+    public IListener Listener => _listener;
 
     /// <summary>
     ///   Determines if the database is in a restoring state.

--- a/src/SmoFacade/Listener.cs
+++ b/src/SmoFacade/Listener.cs
@@ -9,7 +9,7 @@ namespace AgDatabaseMove.SmoFacade
   using System.Threading.Tasks;
 
 
-  internal interface IListener : IDisposable
+  public interface IListener : IDisposable
   {
     /// <summary>
     ///   The primary instance at the time of construction.

--- a/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
+++ b/tests/AgDatabaseMove.Integration/Fixtures/TestAgDatabaseFixture.cs
@@ -51,9 +51,9 @@
     private IEnumerable<SmoFacade.Login> GetCreatedLogins()
     {
       List<SmoFacade.Login> logins = new List<SmoFacade.Login>();
-      logins.Add(_agDatabase._listener.Primary.Logins
+      logins.Add(_agDatabase.Listener.Primary.Logins
                    .SingleOrDefault(l => l.Name.Equals(_loginConfig.LoginName, StringComparison.InvariantCultureIgnoreCase)));
-      foreach (var server in _agDatabase._listener.Secondaries)
+      foreach (var server in _agDatabase.Listener.Secondaries)
       {
         logins.Add(server.Logins
                      .SingleOrDefault(l => l.Name.Equals(_loginConfig.LoginName, StringComparison.InvariantCultureIgnoreCase)));

--- a/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
+++ b/tests/AgDatabaseMove.Integration/TestAgDatabase.cs
@@ -29,14 +29,14 @@
     [Fact]
     public void TestUserExists()
     {
-      var db = _fixture._agDatabase._listener.Primary.Database(_fixture._agConfig.DatabaseName);
+      var db = _fixture._agDatabase.Listener.Primary.Database(_fixture._agConfig.DatabaseName);
       Assert.Contains(_fixture._loginConfig.LoginName, db.Users.Select(u => u.Name));
     }
 
     [Fact]
     public void TestUserHasRoles()
     {
-      var db = _fixture._agDatabase._listener.Primary.Database(_fixture._agConfig.DatabaseName)._database;
+      var db = _fixture._agDatabase.Listener.Primary.Database(_fixture._agConfig.DatabaseName)._database;
       var user = db.Users[_fixture._loginConfig.LoginName];
       Assert.True(user.EnumRoles().Contains("db_datareader"));
     }
@@ -44,7 +44,7 @@
     [Fact]
     public void TestUserHasPermissions()
     {
-      var db = _fixture._agDatabase._listener.Primary.Database(_fixture._loginConfig.DefaultDatabase)._database;
+      var db = _fixture._agDatabase.Listener.Primary.Database(_fixture._loginConfig.DefaultDatabase)._database;
       var permissions = db.EnumDatabasePermissions(_fixture._loginConfig.LoginName);
       Assert.NotNull(permissions.FirstOrDefault(p => p.PermissionType.Execute));
     }

--- a/tests/AgDatabaseMove.Integration/TestRestore.cs
+++ b/tests/AgDatabaseMove.Integration/TestRestore.cs
@@ -37,7 +37,7 @@ namespace AgDatabaseMove.Integration
       _test.Delete();
 
       // We only snapshot the primary instance's logins. It works for our integration environment, but we could do better and snapshot each instance's.
-      _test._listener.ForEachAgInstance(server => {
+      _test.Listener.ForEachAgInstance(server => {
         _preTestLogins.Add(server.Name, server.Logins.Select(l => l.Properties()).ToList());
       });
 
@@ -46,7 +46,7 @@ namespace AgDatabaseMove.Integration
     public void Dispose()
     {
       if(_test != null) {
-        _test._listener.ForEachAgInstance(CleanupLogins);
+        _test.Listener.ForEachAgInstance(CleanupLogins);
         _test.Dispose();
       }
 


### PR DESCRIPTION
I have a need for the internals of `IListener` to be made public. Specifically, I'm trying to avoid having to re-write code to get the names of/connections to replicas in an availability group.

The concrete implementation `Listener` is still internal and therefore can't be directly instantiated... I believe that should be sufficient protection.