### PR TITLE
fix(build): UseDotNet

### DIFF
--- a/build/azure-pipelines.yml
+++ b/build/azure-pipelines.yml
@@ -20,6 +20,12 @@ jobs:
           BuildConfiguration: Debug
 
     steps:
+    - task: UseDotNet@2
+      displayName: 'Use dotnet 3.1.x'
+      inputs:
+        packageType: sdk
+        version: 3.1.x
+        installationPath: $(Agent.ToolsDirectory)/dotnet
     - task: DotNetCoreCLI@2
       inputs:
         command: 'restore'


### PR DESCRIPTION
Build had been failing with the message:

```
Info: .NET Core SDK/runtime 2.2 and 3.0 are now End of Life(EOL) and have been removed from all hosted agents. If you're using these SDK/runtimes on hosted agents, kindly upgrade to newer versions which are not EOL, or else use UseDotNet task to install the required version.
...
Test Run Aborted.
##[error]Error: The process 'C:\Program Files\dotnet\dotnet.exe' failed with exit code 1
Result Attachments will be stored in LogStore
Run Attachments will be stored in LogStore
No Result Found to Publish 'D:\a\_temp\VssAdministrator_fv-az2425-926_2023-09-13_19_00_57.trx'.
##[warning].NET 5 has some compatibility issues with older Nuget versions(<=5.7), so if you are using an older Nuget version(and not dotnet cli) to restore, then the dotnet cli commands (e.g. dotnet build) which rely on such restored packages might fail. To mitigate such error, you can either: (1) - Use dotnet cli to restore, (2) - Use Nuget version 5.8 to restore, (3) - Use global.json using an older sdk version(<=3) to build
Info: Azure Pipelines hosted agents have been updated and now contain .Net 5.x SDK/Runtime along with the older .Net Core version which are currently lts. Unless you have locked down a SDK version for your project(s), 5.x SDK might be picked up which might have breaking behavior as compared to previous versions.
```

I imagine the recent introduction of .Net 5.x SDK/Runtime to the hosted agents may have impacted the behavior of the build. Using the `UseDotNet` task as mentioned in the first info message and setting the version to `3.1.x` seemed to fix the issue.