### PR TITLE
fix(syslogins): password NULL

### DIFF
--- a/src/SmoFacade/Login.cs
+++ b/src/SmoFacade/Login.cs
@@ -54,7 +54,9 @@ namespace AgDatabaseMove.SmoFacade
     /// <returns>A string containing the hex representation of the password hash.</returns>
     public string PasswordHash()
     {
-      var sql = "SELECT password_hash as passwordHash FROM sys.sql_logins WHERE name = @loginName";
+      var sqlVersion = _server._server.Version;
+      var sql = sqlVersion.Major < 13 ? "SELECT CAST(password AS varbinary(max)) as passwordHash FROM sys.syslogins WHERE name = @loginName" 
+        : "SELECT password_hash as passwordHash FROM sys.sql_logins WHERE name = @loginName";
 
       var cmd = new SqlCommand(sql, _server.SqlConnection);
       var dbName = cmd.CreateParameter();

--- a/src/SmoFacade/Login.cs
+++ b/src/SmoFacade/Login.cs
@@ -54,7 +54,7 @@ namespace AgDatabaseMove.SmoFacade
     /// <returns>A string containing the hex representation of the password hash.</returns>
     public string PasswordHash()
     {
-      var sql = "SELECT CAST(password AS varbinary(max)) as passwordHash FROM sys.syslogins WHERE name = @loginName";
+      var sql = "SELECT password_hash as passwordHash FROM sys.sql_logins WHERE name = @loginName";
 
       var cmd = new SqlCommand(sql, _server.SqlConnection);
       var dbName = cmd.CreateParameter();


### PR DESCRIPTION
Fixes the issue described in https://www.tarynpivots.com/post/system-view-gotcha-with-sql-server-2019/.

In SqlServer 2019, the _sys.syslogins_ view returns `NULL` for the `password` field. _sys.sql_logins_ should be used instead.
Should continue to work for older version of SqlServer as well.