### PR TITLE
feat(backup): optional file name

### DIFF
--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -28,7 +28,8 @@ namespace AgDatabaseMove
     string Name { get; }
     bool Exists();
     void Delete();
-    void LogBackup();
+    void FullBackup(string fileName = null);
+    void LogBackup(string fileName = null);
     List<SingleBackup> RecentBackups();
     void JoinAg();
 
@@ -118,9 +119,9 @@ namespace AgDatabaseMove
     /// <summary>
     ///   Takes a log backup on the primary instance.
     /// </summary>
-    public void LogBackup()
+    public void LogBackup(string fileName = null)
     {
-      Listener.Primary.LogBackup(Name, _backupPathSqlQuery);
+      Listener.Primary.LogBackup(Name, _backupPathSqlQuery, fileName);
     }
 
     /// <summary>
@@ -273,9 +274,9 @@ namespace AgDatabaseMove
       Listener?.Dispose();
     }
 
-    public void FullBackup()
+    public void FullBackup(string fileName = null)
     {
-      Listener.Primary.FullBackup(Name, _backupPathSqlQuery);
+      Listener.Primary.FullBackup(Name, _backupPathSqlQuery, fileName);
     }
 
     public void FinalizePrimary()

--- a/src/AgDatabase.cs
+++ b/src/AgDatabase.cs
@@ -28,8 +28,8 @@ namespace AgDatabaseMove
     string Name { get; }
     bool Exists();
     void Delete();
-    void FullBackup(string fileName = null);
-    void LogBackup(string fileName = null);
+    void FullBackup();
+    void LogBackup();
     List<SingleBackup> RecentBackups();
     void JoinAg();
 
@@ -63,6 +63,7 @@ namespace AgDatabaseMove
   public class AgDatabase : IDisposable, IAgDatabase
   {
     private readonly string _backupPathSqlQuery;
+    private readonly Func<string, BackupFileTools.BackupType, string> _backupFileNamer;
 
     /// <summary>
     ///   A constructor that uses a config object for more options.
@@ -72,6 +73,7 @@ namespace AgDatabaseMove
     {
       Name = dbConfig.DatabaseName;
       _backupPathSqlQuery = dbConfig.BackupPathSqlQuery;
+      _backupFileNamer = dbConfig.BackupFileNamer;
       Listener = new Listener(new SqlConnectionStringBuilder(dbConfig.ConnectionString) { InitialCatalog = "master" },
                                dbConfig.CredentialName);
     }
@@ -119,9 +121,9 @@ namespace AgDatabaseMove
     /// <summary>
     ///   Takes a log backup on the primary instance.
     /// </summary>
-    public void LogBackup(string fileName = null)
+    public void LogBackup()
     {
-      Listener.Primary.LogBackup(Name, _backupPathSqlQuery, fileName);
+      Listener.Primary.LogBackup(Name, _backupPathSqlQuery, _backupFileNamer);
     }
 
     /// <summary>
@@ -274,9 +276,9 @@ namespace AgDatabaseMove
       Listener?.Dispose();
     }
 
-    public void FullBackup(string fileName = null)
+    public void FullBackup()
     {
-      Listener.Primary.FullBackup(Name, _backupPathSqlQuery, fileName);
+      Listener.Primary.FullBackup(Name, _backupPathSqlQuery, _backupFileNamer);
     }
 
     public void FinalizePrimary()

--- a/src/DatabaseConfig.cs
+++ b/src/DatabaseConfig.cs
@@ -1,5 +1,6 @@
 ﻿namespace AgDatabaseMove
 {
+  using System;
   using SmoFacade;
 
 
@@ -25,6 +26,15 @@
     ///   <example> SELECT Backup_path FROM [msdb].[dbo].[_Sys_Backup_config]</example>
     /// </summary>
     public string BackupPathSqlQuery { get; set; }
+
+    /// <summary>
+    ///   Optional delegate to customize backup file naming. Receives the database name and backup type,
+    ///   and returns the file path relative to the backup directory, excluding the file extension.
+    ///   The library appends the appropriate extension (.bak, .trn, .diff) automatically.
+    ///   When null, the default naming convention is used:
+    ///   {ComputerNamePhysicalNetBIOS}/{databaseName}/{databaseName}_backup_{timestamp}
+    /// </summary>
+    public Func<string, BackupFileTools.BackupType, string> BackupFileNamer { get; set; }
 
     /// <summary>
     ///   Server credential used for backup and restore operations. Necessary for SqlServer 2012 and older

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -307,11 +307,11 @@ namespace AgDatabaseMove.SmoFacade
     ///   {0} databaseName
     ///   {1} time
     /// </param>
-    public void LogBackup(string databaseName, string backupDirectoryPathQuery = null)
+    public void LogBackup(string databaseName, string backupDirectoryPathQuery = null, string fileName = null)
     {
       var backup = new Backup
         { Action = BackupActionType.Log, Database = databaseName, LogTruncation = BackupTruncateLogType.Truncate };
-      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Log);
+      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Log, fileName);
     }
 
     /// <summary>
@@ -324,20 +324,21 @@ namespace AgDatabaseMove.SmoFacade
     ///   {0} databaseName
     ///   {1} time
     /// </param>
-    public void FullBackup(string databaseName, string backupDirectoryPathQuery = null)
+    public void FullBackup(string databaseName, string backupDirectoryPathQuery = null, string fileName = null)
     {
       var backup = new Backup {
         Action = BackupActionType.Database, Database = databaseName, LogTruncation = BackupTruncateLogType.NoTruncate
       };
-      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Full);
+      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Full, fileName);
     }
 
     private void Backup(Backup backup, string backupDirectoryPathQuery, string databaseName,
-      BackupFileTools.BackupType type)
+      BackupFileTools.BackupType type, string fileName)
     {
       var backupDirectory = BackupDirectoryOrDefault(backupDirectoryPathQuery);
+      var file = fileName ?? $"{_server.ComputerNamePhysicalNetBIOS}/{databaseName}/{databaseName}_backup_{DateTime.Now:yyyy_MM_dd_hhmmss_fff}.{BackupFileTools.BackupTypeToExtension(type)}";
       var filePath =
-        $"{backupDirectory}/{_server.ComputerNamePhysicalNetBIOS}/{databaseName}/{databaseName}_backup_{DateTime.Now.ToString("yyyy_MM_dd_hhmmss_fff")}.{BackupFileTools.BackupTypeToExtension(type)}";
+        $"{backupDirectory}/{file}";
       var deviceType = BackupFileTools.IsValidFileUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);

--- a/src/SmoFacade/Server.cs
+++ b/src/SmoFacade/Server.cs
@@ -307,11 +307,12 @@ namespace AgDatabaseMove.SmoFacade
     ///   {0} databaseName
     ///   {1} time
     /// </param>
-    public void LogBackup(string databaseName, string backupDirectoryPathQuery = null, string fileName = null)
+    public void LogBackup(string databaseName, string backupDirectoryPathQuery = null,
+      Func<string, BackupFileTools.BackupType, string> backupFileNamer = null)
     {
       var backup = new Backup
         { Action = BackupActionType.Log, Database = databaseName, LogTruncation = BackupTruncateLogType.Truncate };
-      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Log, fileName);
+      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Log, backupFileNamer);
     }
 
     /// <summary>
@@ -324,21 +325,31 @@ namespace AgDatabaseMove.SmoFacade
     ///   {0} databaseName
     ///   {1} time
     /// </param>
-    public void FullBackup(string databaseName, string backupDirectoryPathQuery = null, string fileName = null)
+    public void FullBackup(string databaseName, string backupDirectoryPathQuery = null,
+      Func<string, BackupFileTools.BackupType, string> backupFileNamer = null)
     {
       var backup = new Backup {
         Action = BackupActionType.Database, Database = databaseName, LogTruncation = BackupTruncateLogType.NoTruncate
       };
-      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Full, fileName);
+      Backup(backup, backupDirectoryPathQuery, databaseName, BackupFileTools.BackupType.Full, backupFileNamer);
+    }
+
+    private string BackupFileNameOrDefault(Func<string, BackupFileTools.BackupType, string> backupFileNamer,
+      string databaseName, BackupFileTools.BackupType type)
+    {
+      var ext = BackupFileTools.BackupTypeToExtension(type);
+      var baseName = backupFileNamer != null
+        ? backupFileNamer(databaseName, type)
+        : $"{_server.ComputerNamePhysicalNetBIOS}/{databaseName}/{databaseName}_backup_{DateTime.Now:yyyy_MM_dd_hhmmss_fff}";
+      return $"{baseName}.{ext}";
     }
 
     private void Backup(Backup backup, string backupDirectoryPathQuery, string databaseName,
-      BackupFileTools.BackupType type, string fileName)
+      BackupFileTools.BackupType type, Func<string, BackupFileTools.BackupType, string> backupFileNamer)
     {
       var backupDirectory = BackupDirectoryOrDefault(backupDirectoryPathQuery);
-      var file = fileName ?? $"{_server.ComputerNamePhysicalNetBIOS}/{databaseName}/{databaseName}_backup_{DateTime.Now:yyyy_MM_dd_hhmmss_fff}.{BackupFileTools.BackupTypeToExtension(type)}";
-      var filePath =
-        $"{backupDirectory}/{file}";
+      var file = BackupFileNameOrDefault(backupFileNamer, databaseName, type);
+      var filePath = $"{backupDirectory}/{file}";
       var deviceType = BackupFileTools.IsValidFileUrl(filePath) ? DeviceType.Url : DeviceType.File;
 
       var bdi = new BackupDeviceItem(filePath, deviceType);


### PR DESCRIPTION
This change adds an option to configure backup file naming. The naming convention was previously hardcoded in `Server.cs`. This provides the ability to customize that naming convention with an optional delegate which takes `databaseName` and `backupType` since these are commonly used in backup names. 